### PR TITLE
Refactor: Move compile_commands cache from project directory to .mcp_cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ make ie                         # install-editable
 
 **5. Compile Commands Integration**
 - Parses compile_commands.json for accurate per-file compilation arguments
-- Binary caching (.clang_index/compile_commands.cache) for 10-100x faster startup
+- Binary caching (.mcp_cache/<project>/compile_commands/<hash>.cache) for 10-100x faster startup
 - Optional orjson for 3-5x faster JSON parsing (pip install .[performance])
 - Fallback to hardcoded args if compile_commands.json not found
 - See mcp_server/compile_commands_manager.py
@@ -386,6 +386,6 @@ If auto-download fails, manually download from https://github.com/llvm/llvm-proj
 
 5. **Multi-process mode:** Default mode bypasses GIL for true parallelism. If debugging parse issues, set `CPP_ANALYZER_USE_THREADS=true` to use ThreadPoolExecutor (easier to debug, but slower).
 
-6. **SQLite cache:** Lives in `.clang_index/` (multi-config support). Safe to delete for fresh indexing. WAL mode enables concurrent access.
+6. **SQLite cache:** Lives in `.mcp_cache/` (multi-config support). Compile commands cache stored in `.mcp_cache/<project>/compile_commands/`. Safe to delete for fresh indexing. WAL mode enables concurrent access.
 
 7. **Test before committing:** Always run `make test` and `make check` before creating PRs.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -200,7 +200,7 @@ Place `.cpp-analyzer-config.json` (note the leading dot) in your C++ project roo
 ```
 
 **Notes**:
-- `cache_expiry_seconds`: This setting is deprecated. The new binary cache (`.clang_index/compile_commands.cache`) is hash-validated and doesn't use time-based expiry.
+- `cache_expiry_seconds`: This setting is deprecated. The new binary cache (`.mcp_cache/<project>/compile_commands/<hash>.cache`) is hash-validated and doesn't use time-based expiry.
 - `supported_extensions`: Only files with these extensions will be analyzed from `compile_commands.json`
 - `exclude_patterns`: Additional glob patterns to exclude files found in `compile_commands.json`
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The analyzer includes several automatic optimizations:
    - Can be disabled via `CPP_ANALYZER_USE_THREADS=true` environment variable
 
 2. **Binary Caching**
-   - Parsed `compile_commands.json` cached in `.clang_index/compile_commands.cache`
+   - Parsed `compile_commands.json` cached in `.mcp_cache/<project>/compile_commands/<hash>.cache`
    - 10-100x faster subsequent startups for large projects
    - Automatically invalidated when `compile_commands.json` changes
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -41,7 +41,7 @@ If ProcessPoolExecutor shows **1.5x+ speedup**, Python's GIL is limiting paralle
    ```
 
 2. **Use binary cache** (10-100x speedup on subsequent starts):
-   - Cache is automatic, stored in `.clang_index/compile_commands.cache`
+   - Cache is automatic, stored in `.mcp_cache/<project>/compile_commands/<hash>.cache`
    - First load: parses JSON, saves cache
    - Subsequent loads: loads from cache (~0.1s instead of seconds)
    - Cache auto-invalidates when `compile_commands.json` changes

--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -182,9 +182,13 @@ class CppAnalyzer:
         self.max_parse_retries = self.config.config.get("max_parse_retries", 2)
         self.cache_loaded = False  # Track whether cache was successfully loaded
 
-        # Initialize compile commands manager with config
+        # Initialize compile commands manager with config and cache directory
         compile_commands_config = self.config.get_compile_commands_config()
-        self.compile_commands_manager = CompileCommandsManager(self.project_root, compile_commands_config)
+        self.compile_commands_manager = CompileCommandsManager(
+            self.project_root,
+            compile_commands_config,
+            cache_dir=self.cache_manager.cache_dir
+        )
 
         # Initialize header processing tracker for first-win strategy
         self.header_tracker = HeaderProcessingTracker()

--- a/tests/test_compile_commands_cache_location.py
+++ b/tests/test_compile_commands_cache_location.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Test script to verify compile_commands cache works with multiple builds."""
+
+import tempfile
+import json
+from pathlib import Path
+from mcp_server.cpp_analyzer import CppAnalyzer
+from mcp_server.project_identity import ProjectIdentity
+from mcp_server.cache_manager import CacheManager
+
+def test_multiple_builds():
+    """Test that different compile_commands.json paths get different caches."""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_root = Path(tmpdir)
+
+        # Create source files
+        (project_root / "src").mkdir()
+        (project_root / "src" / "main.cpp").write_text("int main() {}")
+
+        # Create two different build directories with compile_commands.json
+        build_debug = project_root / "build.debug"
+        build_release = project_root / "build.release"
+        build_debug.mkdir()
+        build_release.mkdir()
+
+        # Debug compile_commands.json
+        debug_cc = [
+            {
+                "directory": str(build_debug),
+                "command": "g++ -g -DDEBUG main.cpp",
+                "file": str(project_root / "src" / "main.cpp")
+            }
+        ]
+        (build_debug / "compile_commands.json").write_text(json.dumps(debug_cc))
+
+        # Release compile_commands.json
+        release_cc = [
+            {
+                "directory": str(build_release),
+                "command": "g++ -O3 -DNDEBUG main.cpp",
+                "file": str(project_root / "src" / "main.cpp")
+            }
+        ]
+        (build_release / "compile_commands.json").write_text(json.dumps(release_cc))
+
+        # Create configs pointing to different compile_commands.json
+        debug_config = {
+            "compile_commands_enabled": True,
+            "compile_commands_path": "build.debug/compile_commands.json"
+        }
+        release_config = {
+            "compile_commands_enabled": True,
+            "compile_commands_path": "build.release/compile_commands.json"
+        }
+
+        debug_config_path = project_root / ".cpp-analyzer-config-debug.json"
+        release_config_path = project_root / ".cpp-analyzer-config-release.json"
+        debug_config_path.write_text(json.dumps(debug_config))
+        release_config_path.write_text(json.dumps(release_config))
+
+        # Create analyzers with different configs
+        print("Creating debug analyzer...")
+        debug_identity = ProjectIdentity(project_root, debug_config_path)
+        debug_cache_mgr = CacheManager(debug_identity)
+        debug_analyzer = CppAnalyzer(str(project_root), str(debug_config_path))
+
+        print("Creating release analyzer...")
+        release_identity = ProjectIdentity(project_root, release_config_path)
+        release_cache_mgr = CacheManager(release_identity)
+        release_analyzer = CppAnalyzer(str(project_root), str(release_config_path))
+
+        # Get cache paths
+        debug_cc_path = debug_analyzer.compile_commands_manager.project_root / debug_analyzer.compile_commands_manager.compile_commands_path
+        release_cc_path = release_analyzer.compile_commands_manager.project_root / release_analyzer.compile_commands_manager.compile_commands_path
+
+        print(f"\nDebug compile_commands.json:   {debug_cc_path}")
+        print(f"Release compile_commands.json: {release_cc_path}")
+
+        debug_cc_cache = debug_analyzer.compile_commands_manager._get_compile_commands_cache_path()
+        release_cc_cache = release_analyzer.compile_commands_manager._get_compile_commands_cache_path()
+
+        print(f"\nDebug cache:   {debug_cc_cache}")
+        print(f"Release cache: {release_cc_cache}")
+
+        # Verify they're different
+        assert debug_cc_cache != release_cc_cache, \
+            "Different compile_commands.json should get different cache files!"
+
+        # Verify they're both in .mcp_cache
+        assert ".mcp_cache" in str(debug_cc_cache), \
+            "Debug cache should be in .mcp_cache"
+        assert ".mcp_cache" in str(release_cc_cache), \
+            "Release cache should be in .mcp_cache"
+
+        # Verify they're in compile_commands subdirectory
+        assert debug_cc_cache.parent.name == "compile_commands", \
+            "Cache should be in compile_commands subdirectory"
+        assert release_cc_cache.parent.name == "compile_commands", \
+            "Cache should be in compile_commands subdirectory"
+
+        print("\n✅ SUCCESS: Different builds get different compile_commands caches!")
+        print(f"   Debug uses:   {debug_cc_cache.name}")
+        print(f"   Release uses: {release_cc_cache.name}")
+
+
+if __name__ == "__main__":
+    test_multiple_builds()

--- a/tests/test_performance_optimizations.py
+++ b/tests/test_performance_optimizations.py
@@ -214,13 +214,23 @@ class TestCompileCommandsBinaryCache(unittest.TestCase):
     """Test binary caching for compile_commands.json"""
 
     def test_cache_path_creation(self):
-        """Cache path should be in .clang_index directory"""
+        """Cache path should be in compile_commands subdirectory"""
         with tempfile.TemporaryDirectory() as tmpdir:
-            manager = CompileCommandsManager(Path(tmpdir), {})
+            # Test with cache_dir (new behavior)
+            cache_dir = Path(tmpdir) / ".mcp_cache" / "test_project"
+            manager = CompileCommandsManager(Path(tmpdir), {}, cache_dir=cache_dir)
             cache_path = manager._get_compile_commands_cache_path()
 
-            self.assertTrue(str(cache_path).endswith('compile_commands.cache'))
-            self.assertIn('.clang_index', str(cache_path))
+            self.assertTrue(str(cache_path).endswith('.cache'))
+            self.assertIn('compile_commands', str(cache_path))
+            self.assertIn('.mcp_cache', str(cache_path))
+
+            # Test without cache_dir (legacy fallback)
+            manager_legacy = CompileCommandsManager(Path(tmpdir), {})
+            cache_path_legacy = manager_legacy._get_compile_commands_cache_path()
+
+            self.assertTrue(str(cache_path_legacy).endswith('compile_commands.cache'))
+            self.assertIn('.clang_index', str(cache_path_legacy))
 
     def test_file_hash_calculation(self):
         """File hash should be calculated correctly"""


### PR DESCRIPTION
## Summary

Move the compile_commands.json binary cache from the project's `.clang_index/` directory to `.mcp_cache/<project>/compile_commands/` for better organization and multi-configuration support.

## Motivation

Previously, the compile_commands.json cache was stored in `<project>/.clang_index/compile_commands.cache`, which:
- Polluted C++ project directories with MCP-specific files
- Didn't support multiple build configurations (debug/release would overwrite each other)
- Was inconsistent with the main symbol cache location (`.mcp_cache/`)

## Changes

### Code Changes

**mcp_server/compile_commands_manager.py:**
- Added optional `cache_dir` parameter to `__init__()`
- Modified `_get_compile_commands_cache_path()` to:
  - Store cache in `.mcp_cache/<project>/compile_commands/<hash>.cache` when `cache_dir` is provided
  - Use MD5 hash of compile_commands.json absolute path for uniqueness
  - Fall back to legacy location `.clang_index/compile_commands.cache` for backward compatibility

**mcp_server/cpp_analyzer.py:**
- Pass `cache_dir` from CacheManager to CompileCommandsManager

### Testing

- ✅ Added `tests/test_compile_commands_cache_location.py` to verify multiple build configurations get separate caches
- ✅ Updated `tests/test_performance_optimizations.py` to test both new and legacy behavior
- ✅ All 39 compile_commands_manager tests pass
- ✅ All 16 performance optimization tests pass

### Documentation

Updated all references from `.clang_index/compile_commands.cache` to `.mcp_cache/<project>/compile_commands/<hash>.cache` in:
- CLAUDE.md
- README.md
- CONFIGURATION.md
- TROUBLESHOOTING.md

## Benefits

- **Cleaner project directories**: No more `.clang_index/` pollution in C++ projects
- **Multi-config support**: Debug and release builds maintain separate caches (different hashes)
- **Centralized caching**: All MCP-related caches in one location (`.mcp_cache/`)
- **Backward compatible**: Legacy behavior preserved when cache_dir not provided

## Test Plan

- [x] Run `pytest tests/test_compile_commands_cache_location.py` - verifies multiple build configs
- [x] Run `pytest tests/test_compile_commands_manager.py` - all 39 tests pass
- [x] Run `pytest tests/test_performance_optimizations.py` - all 16 tests pass
- [x] Verify cache is created in `.mcp_cache/` on real project
- [x] Verify backward compatibility (no cache_dir) still uses `.clang_index/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)