### PR TITLE
Fix: Check source file existence before attempting to parse

### DIFF
--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -887,6 +887,21 @@ class CppAnalyzer:
                                    was_cached indicates if it was loaded from cache
         """
         file_path = os.path.abspath(file_path)
+
+        # Check if source file exists before attempting to parse
+        # This prevents expensive libclang parse attempts on non-existent files
+        if not Path(file_path).exists():
+            error_msg = f"Source file does not exist: {file_path}"
+            diagnostics.error(error_msg)
+
+            # Log to centralized error log for diagnostics
+            file_not_found_error = FileNotFoundError(error_msg)
+            self.cache_manager.log_parse_error(
+                file_path, file_not_found_error, "", None, 0
+            )
+
+            return (False, False)
+
         current_hash = self._get_file_hash(file_path)
 
         # Get compilation arguments to compute hash (needed for cache validation)


### PR DESCRIPTION
## Summary

Add an early file existence check in `index_file()` to prevent expensive libclang parse attempts on non-existent files listed in compile_commands.json.

## Problem

When `compile_commands.json` contains entries for auto-generated files that no longer exist (e.g., Qt moc files, qrc files from old builds), the analyzer would attempt to parse them, leading to confusing error messages:

**Before fix:**
```
[ERROR] Failed to parse /home/user/build.debug/QtStoryBook/QtStoryBook_autogen/mocs_compilation.cpp
[ERROR]   Error: TranslationUnitLoadError: Error parsing translation unit.
[ERROR]   Compilation args (208 total):
[ERROR]     [0] --driver-mode=g++
[ERROR]     [1] -DBOOST_ALL_DYN_LINK
[ERROR]     [2] -DBOOST_ALL_NO_LIB
...
[ERROR]     ... and 198 more args
[ERROR]   Possible issues:
[ERROR]     - C++ standard specified: ['-std=c++17']
[ERROR]     - Using args from compile_commands.json - check if they are libclang-compatible
```

The error shows compilation arguments and suggests it's a parsing issue, when actually the file simply doesn't exist.

## Solution

Check if the file exists immediately after converting to absolute path. If not, log a clear error and skip parsing.

**After fix:**
```
[ERROR] Source file does not exist: /home/user/build.debug/QtStoryBook/QtStoryBook_autogen/mocs_compilation.cpp
```

## Implementation

```python
# Check if source file exists before attempting to parse
# This prevents expensive libclang parse attempts on non-existent files
if not Path(file_path).exists():
    error_msg = f"Source file does not exist: {file_path}"
    diagnostics.error(error_msg)

    # Log to centralized error log for diagnostics
    file_not_found_error = FileNotFoundError(error_msg)
    self.cache_manager.log_parse_error(
        file_path, file_not_found_error, "", None, 0
    )

    return (False, False)
```

Location: `mcp_server/cpp_analyzer.py:891-903`

## Benefits

✅ **Clearer error messages**: "Source file does not exist" vs confusing TranslationUnitLoadError
✅ **Faster indexing**: Skip expensive libclang parse attempts on non-existent files
✅ **Better UX**: Users immediately understand the issue (stale compile_commands.json)
✅ **Still logged**: Error still appears in centralized parse error log for diagnostics
✅ **Minimal change**: Only 15 lines added, no breaking changes

## Common Scenarios

This helps with:
- **Stale build directories**: Auto-generated files from old builds no longer exist
- **Qt projects**: `moc_*.cpp`, `qrc_*.cpp`, `ui_*.h` files from previous builds
- **Build system changes**: Files moved or renamed but compile_commands.json not updated
- **Multi-build configs**: compile_commands.json from debug build used with release source tree

## Testing

- ✅ All 437 tests pass
- ✅ Verified clear error message for non-existent files
- ✅ Verified real files still parse correctly  
- ✅ Tested with temp files and actual Qt project structure

## Example Test

```python
# Non-existent file
analyzer = CppAnalyzer('/tmp/project')
success, cached = analyzer.index_file('/tmp/project/does_not_exist.cpp')
# Output: [ERROR] Source file does not exist: /tmp/project/does_not_exist.cpp
# Returns: (False, False)

# Real file
Path('/tmp/project/real.cpp').write_text('int main() {}')
success, cached = analyzer.index_file('/tmp/project/real.cpp')
# Parses successfully
# Returns: (True, False)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)