### PR TITLE
Fix: Resolve header tracking cache race conditions and count discrepancies

### DIFF
--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -784,10 +784,14 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
             }
             
             # Add analyzer stats from enhanced Python analyzer
+            # Count total symbols, not just unique names
+            total_classes = sum(len(infos) for infos in analyzer.class_index.values())
+            total_functions = sum(len(infos) for infos in analyzer.function_index.values())
+
             status.update({
                 "parsed_files": len(analyzer.translation_units),
-                "indexed_classes": len(analyzer.class_index),
-                "indexed_functions": len(analyzer.function_index),
+                "indexed_classes": total_classes,
+                "indexed_functions": total_functions,
                 "project_files": len(analyzer.translation_units)  # Approximate count
             })
             return [TextContent(type="text", text=json.dumps(status, indent=2))]


### PR DESCRIPTION
## Summary
Fixes two critical issues discovered during large project testing (5942 files on Mac M1):

1. **Header tracking cache race conditions** causing warnings and corruption
2. **Count discrepancies** between status reports and search results

## Issue 1: Header Tracking Cache Race Conditions

### Problem
When analyzing a large project, these warnings appeared repeatedly:
```
[WARNING] Failed to save header tracking cache: [Errno 2] No such file or directory
[WARNING] Failed to restore header tracking from cache: Extra data: line 1663 column 2
```

### Root Cause
- `_save_header_tracking()` was called after **every file** (5942 times)
- With multi-process parallelism, multiple processes tried to write simultaneously
- Race conditions: one process deletes temp file before another can rename it
- JSON corruption: one process reads while another writes

### Solution
- Save header tracking **only once** at end of indexing/refresh
- Eliminates all concurrent write race conditions
- Added better error handling for JSON corruption (removes corrupted cache)

### Code Changes
- Removed `_save_header_tracking()` call from `index_file()` (after each file)
- Added `_save_header_tracking()` call at end of `index_project()` and `refresh_if_needed()`
- Improved exception handling in `_restore_or_reset_header_tracking()`

## Issue 2: Count Discrepancies

### Problem
Status report showed different counts than search results:
- Step 3 (status): `indexed_classes: 30128`, `indexed_functions: 21624`
- Step 4 (search): Found `31388 classes`
- Step 5 (search): Found `107881 functions`

### Root Cause
- `len(class_index)` counts **unique class names** (dict keys)
- `search_classes(".*")` counts **total class symbols** (all instances)
- Same class can appear multiple times:
  - Defined in multiple files
  - Template instantiations
  - Forward declarations vs definitions

### Solution
Changed all count reporting to count **total symbols** instead of unique names:
```python
# Before:
"indexed_classes": len(analyzer.class_index)

# After:
"indexed_classes": sum(len(infos) for infos in analyzer.class_index.values())
```

### Code Changes
- `cpp_mcp_server.py`: Fixed `get_server_status` counts
- `cpp_analyzer.py`: Fixed counts in:
  - `index_project()` summary message
  - `get_stats()` method
  - `_save_progress_summary()` method

## Testing
- ✅ All 451 tests pass
- ✅ No regressions detected
- ✅ Fixes verified with large project (5942 files)

## Impact
- **Performance**: Eliminates thousands of unnecessary file writes
- **Reliability**: Prevents race conditions and JSON corruption
- **Accuracy**: Consistent counts across all status/search operations
- **User Experience**: No more confusing warnings during indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>