### PR TITLE
Fix: Prevent database corruption on interrupt (Ctrl-C)

### DIFF
--- a/docs/INTERRUPT_HANDLING.md
+++ b/docs/INTERRUPT_HANDLING.md
@@ -1,0 +1,228 @@
+# Interrupt Handling (Ctrl-C) in C++ MCP Server
+
+This document explains how the C++ MCP server handles interrupts (Ctrl-C / SIGINT) during indexing, and what to expect when terminating the process.
+
+## Overview
+
+The server uses `ProcessPoolExecutor` for parallel C++ file parsing. When you press Ctrl-C during indexing, the server needs to:
+1. Stop accepting new work
+2. Cancel pending tasks
+3. Wait for running worker processes to finish
+4. Close database connections cleanly
+5. Exit without leaving orphaned processes
+
+## Expected Behavior
+
+### Single Ctrl-C (Clean Shutdown)
+
+**What you should see:**
+```
+Progress: 10/8389 files (0%) - Success: 7 - Failed: 3...
+^C
+[INFO] Indexing interrupted by user (Ctrl-C)
+
+Interrupted by user (Ctrl-C)
+Cleaning up...
+Analyzer closed successfully
+```
+
+**What happens:**
+- KeyboardInterrupt is raised in the main process
+- Executor shutdown is triggered with `executor.shutdown(wait=True)`
+- Pending futures are canceled
+- Running workers complete their current file
+- Database is closed cleanly
+- **No orphaned processes remain**
+
+You may see a few "Exception ignored" messages from libclang if a worker was mid-parsing when interrupted. This is normal and harmless.
+
+### Multiple Ctrl-C (Forceful Termination)
+
+**What you should see:**
+Many stack traces from worker processes, showing KeyboardInterrupt at various points in multiprocessing internals.
+
+**Why this happens:**
+- First Ctrl-C: Starts clean shutdown
+- Second/Third Ctrl-C: SIGINT sent to all processes again
+- Worker processes dump stack traces before being killed
+- This is **expected behavior** for forceful termination
+
+**Recommendation:**
+Press Ctrl-C **ONCE** and wait 1-2 seconds for clean shutdown. Only press multiple times if the process appears hung (very rare).
+
+## Common Issues and Solutions
+
+### Issue: "database disk image is malformed"
+
+**Cause:** Database was corrupted by:
+- Previous interrupted session (before fixes)
+- SIGKILL (kill -9) instead of SIGINT
+- Power loss / system crash
+- Disk I/O errors
+
+**Solution:**
+```bash
+# Check and fix corrupted database
+python scripts/fix_corrupted_cache.py /path/to/project
+
+# Or manually delete cache
+rm -rf ~/.mcp_cache/
+```
+
+### Issue: Orphaned python processes after interrupt
+
+**Check:**
+```bash
+ps aux | grep python
+```
+
+**Expected:** Only your current shell's python process (if any)
+
+**If you see orphaned workers:**
+This indicates a bug in interrupt handling. Please report with:
+1. Python version: `python --version`
+2. OS: `uname -a`
+3. Steps to reproduce
+
+### Issue: "Exception ignored in: <function _CXString.__del__>"
+
+**This is normal** when interrupting mid-parse. libclang's Python bindings use ctypes callbacks that can't be cleanly canceled. These exceptions are harmless and don't indicate corruption.
+
+## Implementation Details
+
+### Signal Handling Strategy
+
+**Before (problematic):**
+- Custom signal handlers registered with `signal.signal()`
+- Signal handlers inherited by worker processes
+- Workers tried to close database on SIGINT → corruption
+
+**Current (correct):**
+- No custom signal handlers
+- Python's built-in KeyboardInterrupt exception handling
+- Only main process closes database
+- Workers receive SIGINT but don't access database
+- `executor.shutdown(wait=True)` ensures clean worker termination
+
+### Code Locations
+
+- **Main interrupt handling:** `mcp_server/cpp_analyzer.py:1449-1464`
+  - KeyboardInterrupt exception handler
+  - Executor shutdown with `wait=True`
+
+- **Test scripts:**
+  - `scripts/test_mcp_console.py` - Manual testing
+  - `scripts/test_interrupt_cleanup.py` - Verify no orphaned processes
+
+### Why asyncio.run() was removed
+
+The test scripts originally used `asyncio.run()` which:
+- Installs its own signal handler (`_on_sigint`)
+- Raises KeyboardInterrupt in ALL processes (main + workers)
+- Caused excessive stack traces even on single Ctrl-C
+
+Since the test functions weren't actually async (no `await`), we removed asyncio entirely for cleaner interrupt handling.
+
+## Testing Interrupt Handling
+
+### Manual Test
+
+```bash
+# Start indexing a large project
+python scripts/test_mcp_console.py /path/to/large/project
+
+# Wait for indexing to start (see progress output)
+# Press Ctrl-C ONCE
+# Wait 1-2 seconds
+
+# Verify clean shutdown:
+# - Should see "Indexing interrupted by user (Ctrl-C)"
+# - Should see "Analyzer closed successfully"
+# - No database corruption errors
+
+# Verify no orphaned processes:
+ps aux | grep python
+# Should see only your shell (if any)
+```
+
+### Automated Test
+
+```bash
+# Verify executor cleanup
+python scripts/test_interrupt_cleanup.py /path/to/project
+# Press Ctrl-C during indexing
+# Check ps output at the end
+```
+
+## Best Practices
+
+1. **Single Ctrl-C:** Always try single Ctrl-C first and wait for clean shutdown
+2. **Database safety:** SQLite WAL mode allows some concurrent access, but clean shutdown is still important
+3. **Large projects:** Clean shutdown may take 1-2 seconds to cancel all pending work
+4. **If hung:** If process doesn't respond to Ctrl-C within 5 seconds, use `kill` (not `kill -9`)
+
+## Platform Differences
+
+### Linux
+- Clean signal handling with fork-based multiprocessing
+- No known issues
+
+### macOS
+- Same as Linux (fork-based multiprocessing)
+- No known issues
+
+### Windows
+- Uses spawn instead of fork for multiprocessing
+- Signal handling differs slightly
+- Not thoroughly tested yet
+
+## Debugging
+
+### Enable debug logging
+
+```bash
+export MCP_DEBUG=1
+python scripts/test_mcp_console.py /path/to/project
+```
+
+### Check database health
+
+```bash
+# Scan all caches
+python scripts/fix_corrupted_cache.py
+
+# Check specific project
+python scripts/fix_corrupted_cache.py /path/to/project
+```
+
+### Profile interrupt timing
+
+```bash
+time python scripts/test_mcp_console.py /path/to/project
+# Press Ctrl-C immediately after indexing starts
+# Time should be < 3 seconds for clean shutdown
+```
+
+## Related Files
+
+- `mcp_server/cpp_analyzer.py` - Main interrupt handling
+- `scripts/test_mcp_console.py` - Manual test script
+- `scripts/test_interrupt_cleanup.py` - Automated test
+- `scripts/fix_corrupted_cache.py` - Database recovery tool
+- `CLAUDE.md` - Architecture documentation
+
+## Future Improvements
+
+Possible enhancements (not currently implemented):
+- Progress bar that updates during shutdown
+- Estimate of shutdown time remaining
+- Save partial results on interrupt
+- Resume from partial indexing
+
+## Questions?
+
+If you encounter issues not covered here:
+1. Check the issue tracker
+2. Run with `MCP_DEBUG=1` for verbose output
+3. Check database health with `fix_corrupted_cache.py`
+4. Report bugs with full reproduction steps

--- a/scripts/fix_corrupted_cache.py
+++ b/scripts/fix_corrupted_cache.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Fix corrupted database cache
+
+This script helps diagnose and fix corrupted SQLite database caches
+that can occur if indexing is interrupted improperly.
+
+Usage:
+    python scripts/fix_corrupted_cache.py [project_path]
+
+If project_path is not provided, it will check all cache directories.
+"""
+
+import sys
+import os
+import sqlite3
+import shutil
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def check_database(db_path):
+    """Check if a database is corrupted"""
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        # Try a simple query
+        cursor.execute("PRAGMA integrity_check;")
+        result = cursor.fetchone()
+
+        conn.close()
+
+        if result and result[0] == 'ok':
+            return True, "Database is healthy"
+        else:
+            return False, f"Database integrity check failed: {result}"
+
+    except sqlite3.DatabaseError as e:
+        return False, f"Database error: {e}"
+    except Exception as e:
+        return False, f"Unexpected error: {e}"
+
+
+def get_cache_directory():
+    """Get the cache directory path"""
+    return Path.home() / '.mcp_cache'
+
+
+def find_project_cache(project_path):
+    """Find cache directory for a specific project"""
+    from mcp_server.project_identity import ProjectIdentity
+
+    project_path = os.path.abspath(project_path)
+
+    # Try to find config file
+    config_file = None
+    config_path = os.path.join(project_path, 'cpp-analyzer-config.json')
+    if os.path.exists(config_path):
+        config_file = config_path
+
+    # Get project identity
+    identity = ProjectIdentity(project_path, config_file)
+    cache_dir = identity.get_cache_directory()
+
+    return cache_dir
+
+
+def remove_cache_directory(cache_dir):
+    """Remove a cache directory"""
+    try:
+        if os.path.exists(cache_dir):
+            shutil.rmtree(cache_dir)
+            return True, f"Removed cache directory: {cache_dir}"
+        else:
+            return False, f"Cache directory does not exist: {cache_dir}"
+    except Exception as e:
+        return False, f"Error removing cache directory: {e}"
+
+
+def scan_all_caches():
+    """Scan all cache directories for corruption"""
+    cache_dir = get_cache_directory()
+
+    if not cache_dir.exists():
+        print(f"No cache directory found at: {cache_dir}")
+        return []
+
+    print(f"Scanning cache directory: {cache_dir}\n")
+
+    results = []
+    for project_dir in cache_dir.iterdir():
+        if not project_dir.is_dir():
+            continue
+
+        db_path = project_dir / 'cache.db'
+        if not db_path.exists():
+            continue
+
+        print(f"Checking: {project_dir.name}")
+        is_healthy, message = check_database(str(db_path))
+
+        results.append({
+            'project_dir': project_dir,
+            'db_path': db_path,
+            'is_healthy': is_healthy,
+            'message': message
+        })
+
+        if is_healthy:
+            print(f"  ✓ {message}")
+        else:
+            print(f"  ✗ {message}")
+
+    return results
+
+
+def main():
+    """Main entry point"""
+    print("=" * 70)
+    print("Database Cache Corruption Fixer")
+    print("=" * 70)
+    print()
+
+    if len(sys.argv) > 1:
+        # Check specific project
+        project_path = sys.argv[1]
+
+        if not os.path.isdir(project_path):
+            print(f"Error: Directory '{project_path}' does not exist")
+            sys.exit(1)
+
+        print(f"Finding cache for project: {project_path}\n")
+
+        try:
+            cache_dir = find_project_cache(project_path)
+            print(f"Cache directory: {cache_dir}\n")
+
+            db_path = Path(cache_dir) / 'cache.db'
+
+            if not db_path.exists():
+                print(f"No database found at: {db_path}")
+                print("The project has not been indexed yet or cache was already cleared.")
+                sys.exit(0)
+
+            print("Checking database integrity...")
+            is_healthy, message = check_database(str(db_path))
+            print(f"{message}\n")
+
+            if not is_healthy:
+                response = input("Database is corrupted. Delete cache and rebuild? [y/N]: ")
+                if response.lower() == 'y':
+                    success, msg = remove_cache_directory(cache_dir)
+                    if success:
+                        print(f"✓ {msg}")
+                        print("\nYou can now re-index the project. The cache will be rebuilt.")
+                    else:
+                        print(f"✗ {msg}")
+                        sys.exit(1)
+                else:
+                    print("Aborted. Cache not deleted.")
+            else:
+                print("Database is healthy. No action needed.")
+
+        except Exception as e:
+            print(f"Error: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+
+    else:
+        # Scan all caches
+        results = scan_all_caches()
+
+        if not results:
+            print("No cache directories found.")
+            sys.exit(0)
+
+        print("\n" + "=" * 70)
+        print("Summary")
+        print("=" * 70)
+
+        corrupted = [r for r in results if not r['is_healthy']]
+
+        if corrupted:
+            print(f"\nFound {len(corrupted)} corrupted database(s):\n")
+            for r in corrupted:
+                print(f"  - {r['project_dir'].name}")
+                print(f"    {r['message']}")
+
+            print("\nTo fix corrupted caches, you can:")
+            print("1. Delete specific project cache:")
+            print("   rm -rf ~/.mcp_cache/<project_dir_name>")
+            print("\n2. Delete all caches:")
+            print("   rm -rf ~/.mcp_cache/")
+            print("\n3. Run this script with the project path:")
+            print("   python scripts/fix_corrupted_cache.py /path/to/project")
+        else:
+            print("\nAll databases are healthy!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_interrupt_cleanup.py
+++ b/scripts/test_interrupt_cleanup.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Test script to verify subprocess cleanup on interrupt
+
+This script indexes a project and can be interrupted with Ctrl-C.
+After interruption, check with 'ps aux | grep python' to verify
+no orphaned worker processes remain.
+
+Usage:
+    python scripts/test_interrupt_cleanup.py <path-to-cpp-project>
+
+Then press Ctrl-C during indexing and verify cleanup.
+"""
+
+import sys
+import os
+import time
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+_analyzer = None
+
+def main():
+    """Main entry point"""
+    if len(sys.argv) < 2:
+        print("Usage: python test_interrupt_cleanup.py <path-to-cpp-project>")
+        print("\nThis script tests subprocess cleanup on interrupt.")
+        print("Start indexing, press Ctrl-C, then check with:")
+        print("  ps aux | grep python")
+        print("\nYou should see no orphaned worker processes.")
+        sys.exit(1)
+
+    project_path = sys.argv[1]
+
+    if not os.path.isdir(project_path):
+        print(f"Error: Directory '{project_path}' does not exist")
+        sys.exit(1)
+
+    try:
+        from mcp_server.cpp_analyzer import CppAnalyzer
+
+        print("=" * 70)
+        print("Testing subprocess cleanup on interrupt (Ctrl-C)")
+        print("=" * 70)
+        print(f"\nIndexing project: {project_path}")
+        print("\nPress Ctrl-C during indexing to test cleanup...")
+        print("After interruption, check with: ps aux | grep python")
+        print("You should see NO orphaned worker processes.\n")
+
+        global _analyzer
+        _analyzer = CppAnalyzer(project_path)
+
+        # Start indexing (this will use ProcessPoolExecutor by default)
+        print("Starting indexing with ProcessPoolExecutor...")
+        indexed_count = _analyzer.index_project(force=True, include_dependencies=True)
+
+        print(f"\n\nIndexing completed successfully: {indexed_count} files indexed")
+        print("\nIf you didn't interrupt, try running again and press Ctrl-C during indexing.")
+
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user (Ctrl-C)", file=sys.stderr)
+        print("Cleaning up...", file=sys.stderr)
+    finally:
+        if _analyzer is not None:
+            try:
+                _analyzer.close()
+                print("Analyzer closed successfully", file=sys.stderr)
+                print("\nCheck for orphaned processes with: ps aux | grep python", file=sys.stderr)
+            except Exception as e:
+                print(f"Error closing analyzer: {e}", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes database corruption issues that occurred when users pressed Ctrl-C multiple times during indexing. The problem was that worker processes would receive SIGINT and attempt to close database connections, leading to corruption.

**Changes:**
- ✅ Proper KeyboardInterrupt exception handling in `cpp_analyzer.py`
- ✅ Executor cleanup in `finally` block ensures worker processes terminate cleanly
- ✅ Pending futures are canceled before executor shutdown
- ✅ Removed `asyncio.run()` from test scripts (was interfering with signal handling)
- ✅ Added comprehensive documentation in `docs/INTERRUPT_HANDLING.md`
- ✅ Added `scripts/fix_corrupted_cache.py` to diagnose and repair corrupted databases
- ✅ Added `scripts/test_interrupt_cleanup.py` to verify proper cleanup
- ✅ Updated `CLAUDE.md` with interrupt handling best practices

**The fix ensures:**
- Single Ctrl-C cleanly shuts down worker processes
- Database connections are properly closed by main process only
- No orphaned worker processes remain
- SQLite WAL mode provides additional protection

**Expected behavior:**
- Single Ctrl-C: Clean shutdown with proper cleanup messages
- Multiple Ctrl-C: Forceful termination with stack traces (expected)

**Testing:**
- All 457 tests pass
- Manual testing with `scripts/test_interrupt_cleanup.py`
- Verified no orphaned processes with `ps aux | grep python`

## Test plan
- [x] Run full test suite (`make test`)
- [x] Manual interrupt testing with sample projects
- [x] Verify no orphaned processes remain after interrupt
- [x] Test database corruption recovery script
- [x] Documentation is comprehensive and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)