### PR TITLE
Fix: Serialize SymbolInfo objects to dicts in cache loading

### DIFF
--- a/mcp_server/sqlite_cache_backend.py
+++ b/mcp_server/sqlite_cache_backend.py
@@ -1448,9 +1448,9 @@ class SqliteCacheBackend:
 
             for symbol in all_symbols:
                 if symbol.kind in ('class', 'struct', 'union', 'enum'):
-                    class_index[symbol.name].append(symbol)
+                    class_index[symbol.name].append(symbol.to_dict())
                 elif symbol.kind in ('function', 'method', 'constructor', 'destructor'):
-                    function_index[symbol.name].append(symbol)
+                    function_index[symbol.name].append(symbol.to_dict())
 
             # Load file hashes
             file_hashes = self.load_all_file_hashes()


### PR DESCRIPTION
## Summary

Fixes critical cache loading bug that prevented cached symbols from being loaded on subsequent runs, causing full re-indexing every time.

**Error message:**
```
[ERROR] Error loading cache: mcp_server.symbol_info.SymbolInfo() argument after ** must be a mapping, not SymbolInfo
```

## Problem

The SQLite backend's `load_cache()` method was returning `SymbolInfo` objects directly in the `class_index` and `function_index` dictionaries (line 1451-1453). However, `cpp_analyzer.py` expected these to be dictionaries and tried to construct new `SymbolInfo` objects using unpacking: `SymbolInfo(**info)` (line 1543, 1547).

This caused a type error when `info` was already a `SymbolInfo` object instead of a dictionary.

## Solution

Convert `SymbolInfo` objects to dictionaries using `.to_dict()` method before adding them to the indexes:

```python
# Before:
class_index[symbol.name].append(symbol)

# After:
class_index[symbol.name].append(symbol.to_dict())
```

This ensures the cache loading interface returns serializable dictionaries as expected by the cache protocol.

## Impact

**Before fix:**
- Second run showed: "Error loading cache"
- Only 136/415 files loaded from cache (32%)
- Re-indexed entire project (~same time as first run)

**After fix:**
- Second run loads all cached symbols successfully
- 100% cache hit rate for unchanged files
- Indexing time drops from minutes to seconds

## Testing

- ✅ All 457 tests pass
- ✅ Verified cache save/load cycle works correctly
- ✅ Tested with real project (5942 files) - second run uses cache properly

## Test plan

- [x] Run full test suite (`make test`)
- [x] Verify cache loading works with test projects
- [x] Confirm second run is significantly faster than first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)