### PR TITLE
Fix: Suppress Python shutdown errors in __del__ methods

### DIFF
--- a/mcp_server/cache_manager.py
+++ b/mcp_server/cache_manager.py
@@ -131,7 +131,15 @@ class CacheManager:
 
     def __del__(self):
         """Destructor to ensure resources are released on garbage collection."""
-        self.close()
+        # During Python shutdown, modules may be None. Suppress all errors.
+        try:
+            # Check if we're shutting down - skip cleanup if so
+            if sys is None or sys.meta_path is None:
+                return
+            self.close()
+        except (ImportError, AttributeError, TypeError):
+            # Suppress errors during shutdown - resources will be cleaned up by OS
+            pass
 
     def _handle_backend_error(self, error: Exception, operation: str) -> bool:
         """

--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -246,7 +246,15 @@ class CppAnalyzer:
 
     def __del__(self):
         """Destructor to ensure resources are released on garbage collection."""
-        self.close()
+        # During Python shutdown, modules may be None. Suppress all errors.
+        try:
+            # Check if we're shutting down - skip cleanup if so
+            if sys is None or sys.meta_path is None:
+                return
+            self.close()
+        except (ImportError, AttributeError, TypeError):
+            # Suppress errors during shutdown - resources will be cleaned up by OS
+            pass
 
     def _get_file_hash(self, file_path: str) -> str:
         """Get hash of file contents for change detection"""


### PR DESCRIPTION
## Summary
Fixed `ImportError` exceptions during Python interpreter shutdown in `CppAnalyzer` and `CacheManager` destructors.

## Problem
When running `scripts/test_mcp_console.py`, the following errors appeared at program exit:

```
Exception ignored in: <function CppAnalyzer.__del__ at 0x103a87740>
Traceback (most recent call last):
  File "mcp_server/cpp_analyzer.py", line 249, in __del__
  File "mcp_server/cpp_analyzer.py", line 236, in close
  File "mcp_server/cache_manager.py", line 119, in close
ImportError: sys.meta_path is None, Python is likely shutting down
```

This occurred because Python's module cleanup during shutdown happens in undefined order. When `__del__` methods executed, they tried to import modules that were already torn down.

## Solution
Enhanced both `__del__` methods to:
1. Detect Python shutdown by checking `sys.meta_path is None`
2. Skip cleanup if shutdown is detected (OS will clean up resources)
3. Wrap cleanup in try/except to suppress any shutdown-related errors

## Changes
- **mcp_server/cache_manager.py**: Added shutdown-safe `__del__` implementation
- **mcp_server/cpp_analyzer.py**: Added shutdown-safe `__del__` implementation

## Testing
- ✅ Tested with `scripts/test_mcp_console.py` - no shutdown errors
- ✅ Tested both fresh indexing and cached runs
- ✅ Full test suite: 442 tests passed, no regressions
- ✅ Verified on both Linux and macOS (user-reported)

## Impact
- **User-facing**: Eliminates confusing error messages at program exit
- **Functionality**: No change to runtime behavior
- **Risk**: Very low - only affects cleanup during shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)