### PR TITLE
Fix: Resolve test failures and cache-related bugs

### DIFF
--- a/mcp_server/sqlite_cache_backend.py
+++ b/mcp_server/sqlite_cache_backend.py
@@ -59,6 +59,9 @@ class SqliteCacheBackend:
     def _connect(self):
         """Open database connection with optimized settings."""
         try:
+            # Ensure parent directory exists
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
             # Configure for concurrent access
             self.conn = sqlite3.connect(
                 str(self.db_path),
@@ -1379,8 +1382,9 @@ class SqliteCacheBackend:
                         base_classes, calls, called_by,
                         start_line, end_line, header_file, header_line,
                         header_start_line, header_end_line, is_definition,
+                        brief, doc_comment,
                         created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     self._symbol_to_tuple(test_symbol)
                 )


### PR DESCRIPTION
## Summary

Fixes 5 test failures reported on Mac M1 and improves test infrastructure reliability.

## Issues Fixed

### 1. SQL Binding Mismatch (test_monitor_performance_write)
- **Problem:** INSERT statement missing `brief` and `doc_comment` columns added in schema v7.0
- **Error:** `Incorrect number of bindings supplied. The current statement uses 23, and there are 25 supplied.`
- **Fix:** Updated INSERT statement to include both documentation columns (23 → 25 placeholders)
- **File:** `mcp_server/sqlite_cache_backend.py:1374-1384`

### 2. Cache Pollution Between Tests (4 test failures)
- **Affected tests:**
  - `test_continue_parsing_with_syntax_errors` 
  - `test_error_message_logged_and_cached`
  - `test_forward_decl_then_real_class_definition_wins`
  - `test_declaration_replaced_when_definition_found`
- **Problem:** Cache directories persisted between tests, causing `was_cached=True` when should be `False`
- **Root cause:** `.mcp_cache/` directories not cleaned between tests; pytest tmp_path reuse picked up stale cache
- **Fix:** Added autouse fixture to automatically clean cache directories after each test
- **File:** `tests/conftest.py` (lines 57-83)

### 3. Database Initialization Error (test_source_file_modification)
- **Problem:** `FileNotFoundError` when recreating database after cache directory cleanup
- **Error:** `[Errno 2] No such file or directory: '.mcp_cache/project_hash/symbols.db'`
- **Root cause:** `_connect()` didn't ensure parent directory existed before creating database
- **Fix:** Added `mkdir(parents=True, exist_ok=True)` in `_connect()` method
- **File:** `mcp_server/sqlite_cache_backend.py:62-63`

## Test Results

**Before:**
```
498 passed, 5 failed, 15 skipped
```

**After:**
```
503 passed, 15 skipped, 4 warnings (all pass)
```

## Changes

- `mcp_server/sqlite_cache_backend.py`: Add missing columns to SQL INSERT + ensure cache dir exists
- `tests/conftest.py`: Add automatic cache cleanup between tests

## Testing

All tests pass on Linux. These fixes specifically address Mac M1 test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)