### PR TITLE
Fix KeyError in test_mcp_console.py when accessing callers result

### DIFF
--- a/scripts/test_mcp_console.py
+++ b/scripts/test_mcp_console.py
@@ -119,11 +119,12 @@ def test_mcp_server(project_path: str):
     # 9. Find callers (if functions exist)
     if functions:
         print(f"\n9. Finding callers of function: {functions[0]['name']}")
-        callers = analyzer.find_callers(functions[0]['name'])
-        print(f"[OK] Found {len(callers)} caller(s)")
-        if callers:
+        callers_result = analyzer.find_callers(functions[0]['name'])
+        callers_list = callers_result.get('callers', [])
+        print(f"[OK] Found {len(callers_list)} caller(s)")
+        if callers_list:
             print("   First 3 callers:")
-            for caller in callers[:3]:
+            for caller in callers_list[:3]:
                 print(f"   - {caller['name']} at {caller['file']}:{caller['line']}")
 
     # 10. Find callees (if functions exist)


### PR DESCRIPTION
## Summary
Fixes KeyError crash in `scripts/test_mcp_console.py` that occurred when trying to display caller information.

## Problem
The script crashed on exit with:
```
Traceback (most recent call last):
  File "scripts/test_mcp_console.py", line 172, in <module>
    main()
  ...
  File "scripts/test_mcp_console.py", line 126, in test_mcp_server
    for caller in callers[:3]:
KeyError: slice(None, 3, None)
```

**Root Cause:**
- `find_callers()` returns a **dictionary** with keys `'callers'` and `'call_sites'`
- Script incorrectly treated the returned dict as a list
- Trying to slice a dict (`callers[:3]`) causes KeyError

## Solution
Extract the `'callers'` list from the returned dictionary:
```python
# Before (incorrect):
callers = analyzer.find_callers(functions[0]['name'])
for caller in callers[:3]:  # KeyError!

# After (correct):
callers_result = analyzer.find_callers(functions[0]['name'])
callers_list = callers_result.get('callers', [])
for caller in callers_list[:3]:  # Works!
```

## Testing
✅ Tested with `examples/compile_commands_example/`
✅ Script completes successfully without errors
✅ Properly displays caller information (or "Found 0 caller(s)" if none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)