### PR TITLE
Fix HTTP/SSE transport to use canonical MCP protocol paths

### DIFF
--- a/docs/archived/REQUIREMENTS_HTTP_SUPPORT.md
+++ b/docs/archived/REQUIREMENTS_HTTP_SUPPORT.md
@@ -1,5 +1,15 @@
 # HTTP/Streamable HTTP Protocol Support Requirements
 
+> **⚠️ ARCHIVED DOCUMENT - OUTDATED INFORMATION**
+>
+> This document contains the original requirements but has **outdated endpoint paths**.
+> The implementation now uses canonical MCP paths:
+> - `/sse` (not `/mcp/v1/sse`)
+> - `/messages` (not `/mcp/v1/messages`)
+> - `Mcp-Session-Id` header (not `x-mcp-session-id`)
+>
+> See [CLIENT_SETUP.md](../../CLIENT_SETUP.md) and [HTTP_USAGE.md](../HTTP_USAGE.md) for current documentation.
+
 ## Overview
 Add HTTP and Server-Sent Events (SSE) transport protocols to the clang_index_mcp server, in addition to the existing stdio transport.
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -111,7 +111,7 @@ async def test_http_messages_endpoint_invalid_json(http_server):
     """Test messages endpoint with invalid JSON."""
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            f"{http_server}/mcp/v1/messages",
+            f"{http_server}/messages",
             content=b"invalid json{",
             headers={"Content-Type": "application/json"}
         )
@@ -136,24 +136,24 @@ async def test_http_session_creation(http_server):
         }
 
         response = await client.post(
-            f"{http_server}/mcp/v1/messages",
+            f"{http_server}/messages",
             json=request_data
         )
 
         # Should get a session ID header
-        assert "x-mcp-session-id" in response.headers
-        session_id = response.headers["x-mcp-session-id"]
+        assert "Mcp-Session-Id" in response.headers
+        session_id = response.headers["Mcp-Session-Id"]
         assert session_id
 
         # Make another request with the same session ID
         response2 = await client.post(
-            f"{http_server}/mcp/v1/messages",
+            f"{http_server}/messages",
             json=request_data,
-            headers={"x-mcp-session-id": session_id}
+            headers={"Mcp-Session-Id": session_id}
         )
 
         # Should get the same session ID back
-        assert response2.headers["x-mcp-session-id"] == session_id
+        assert response2.headers["Mcp-Session-Id"] == session_id
 
 
 @pytest.mark.asyncio
@@ -170,7 +170,7 @@ async def test_http_concurrent_sessions(http_server):
                 "params": {}
             }
             tasks.append(
-                client.post(f"{http_server}/mcp/v1/messages", json=request_data)
+                client.post(f"{http_server}/messages", json=request_data)
             )
 
         responses = await asyncio.gather(*tasks)
@@ -183,7 +183,7 @@ async def test_http_concurrent_sessions(http_server):
             assert response.status_code in (200, 406, 500)
 
         # All should have different session IDs
-        session_ids = [r.headers["x-mcp-session-id"] for r in responses]
+        session_ids = [r.headers["Mcp-Session-Id"] for r in responses]
         assert len(set(session_ids)) == len(session_ids)  # All unique
 
 
@@ -199,7 +199,7 @@ async def test_http_tool_list_request(http_server):
         }
 
         response = await client.post(
-            f"{http_server}/mcp/v1/messages",
+            f"{http_server}/messages",
             json=request_data,
             timeout=10.0
         )


### PR DESCRIPTION
## Summary

Fixes HTTP/SSE transport compatibility with LM Studio and other MCP clients by implementing canonical MCP protocol paths and properly using the MCP SDK's SSE transport.

## Changes

### Core Implementation Fixes

**Endpoint Paths (canonical MCP specification):**
- `/mcp/v1/sse` → `/sse` 
- `/mcp/v1/messages` → `/messages`

**Session Headers (canonical MCP specification):**
- `x-mcp-session-id` → `Mcp-Session-Id`

**SSE Transport (proper MCP SDK usage):**
- Now uses `SseServerTransport.connect_sse()` for SSE stream handling
- Now uses `SseServerTransport.handle_post_message()` for message posting
- SSE stream now sends actual MCP JSON-RPC messages (not just keepalives/pings)
- Fixed ASGI middleware to prevent double response sending error

### Testing

- ✅ All 17 HTTP/SSE transport tests pass
- ✅ Updated `test_http_transport.py` with canonical paths and headers
- ✅ Updated `test_sse_transport.py` to match MCP SDK SSE behavior

### Documentation

- Updated `CLIENT_SETUP.md` with LM Studio compatibility status
- Updated `docs/HTTP_USAGE.md` with correct endpoint examples
- Added deprecation notice to `docs/archived/REQUIREMENTS_HTTP_SUPPORT.md`

## Problem Solved

**Before:** LM Studio could not connect to the HTTP/SSE server due to:
1. Non-standard endpoint paths (`/mcp/v1/*` instead of canonical `/sse` and `/messages`)
2. SSE implementation only sending keepalives, not actual MCP protocol messages
3. Non-standard session header name

**After:** LM Studio successfully connects and retrieves tool list. Server logs show:
```
INFO: GET /sse HTTP/1.1" 200 OK
INFO: POST /messages?session_id=... HTTP/1.1" 202 Accepted
INFO: Processing request of type ListToolsRequest
```

## Testing Instructions

### Test with LM Studio

1. Start server:
   ```bash
   python -m mcp_server.cpp_mcp_server --transport sse --port 8080
   ```

2. Configure LM Studio:
   ```json
   {
     "mcpServers": {
       "cpp-analyzer": {
         "url": "http://127.0.0.1:8080/sse"
       }
     }
   }
   ```

3. Verify connection and tool list retrieval

### Test with curl

```bash
# Test SSE endpoint
curl -N http://127.0.0.1:8080/sse

# Should see:
# event: endpoint
# data: /messages?session_id=...
```

## Related Issues

Resolves compatibility issues documented in the analysis report where LM Studio's MCP bridge was receiving 405 errors due to non-standard endpoint paths.

## Checklist

- [x] Tests pass (17/17 HTTP/SSE tests)
- [x] Documentation updated
- [x] No new dependencies required
- [x] Verified with actual LM Studio connection
- [x] Commit message follows project conventions