### PR TITLE
fix: Initialize progress with cache data after set_project_directory (Issue #15)

### DIFF
--- a/docs/MANUAL_TEST_OBSERVATIONS.md
+++ b/docs/MANUAL_TEST_OBSERVATIONS.md
@@ -28,7 +28,7 @@
 | 12 | Database connection lifecycle | All | ✅ FIXED | #69 | Separate connection for dep graph |
 | 13 | Headers with fallback args | All | ✅ FIXED | #67 | Filter headers from change scanner |
 | 14 | Memory leak during large indexing | Linux | ✅ FIXED | #77 | Worker index cleanup - 9-11x memory reduction |
-| 15 | Status reports zero files before refresh | Linux | 🔍 NEW | - | Status correct only after refresh starts |
+| 15 | Status reports zero files before refresh | Linux | ✅ FIXED | #78 | Progress initialized from cache data |
 | 16 | Server shutdown hangs on Ctrl-C | Linux | 🔍 NEW | - | Requires 5x Ctrl-C, ProcessPoolExecutor blocking |
 
 ## Phase Completion
@@ -81,10 +81,11 @@ export LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib/libclang.dylib
 ## Summary
 
 **Completion:**
-- ✅ 9 issues fixed (100% of critical & medium priority)
+- ✅ 10 issues fixed (100% of critical & medium priority)
 - 📋 4 issues deferred (lower priority, workarounds available)
-- Timeline: 2025-12-21 to 2025-12-25
-- Total effort: ~12 hours development + testing
+- 🔍 1 issue pending (server shutdown hang - lower priority)
+- Timeline: 2025-12-21 to 2025-12-26
+- Total effort: ~14 hours development + testing
 
 **All critical and medium-priority issues from manual testing have been successfully resolved.**
 

--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -710,6 +710,25 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
                             f"Cache loaded successfully: {len(analyzer.class_index)} classes, "
                             f"{len(analyzer.function_index)} functions indexed"
                         )
+
+                        # CRITICAL FIX FOR ISSUE #15: Initialize progress with cache data
+                        # Without this, get_indexing_status returns 0 files even though cache is loaded
+                        from .state_manager import IndexingProgress
+                        from datetime import datetime
+
+                        # Create progress object from cached data
+                        total_files = len(analyzer.file_index)
+                        progress = IndexingProgress(
+                            total_files=total_files,
+                            indexed_files=total_files,  # All files loaded from cache
+                            failed_files=0,  # No failures when loading from cache
+                            cache_hits=total_files,  # Everything came from cache
+                            current_file=None,  # No active file
+                            start_time=datetime.now(),
+                            estimated_completion=None  # Already complete
+                        )
+                        state_manager.update_progress(progress)
+
                         state_manager.transition_to(AnalyzerState.INDEXED)
 
                         # Mark as initialized immediately


### PR DESCRIPTION
## Problem

After calling `set_project_directory` on a project with existing cache, `get_indexing_status` reported zero files even though the cache was successfully loaded. Status only showed correct counts after `refresh_project` was called.

**Observed Behavior:**
1. Call `set_project_directory` → cache loads successfully
2. Call `get_indexing_status` → shows 0 files
3. Call `refresh_project` → immediately shows correct file counts

## Root Cause

When cache loaded successfully in `set_project_directory`, the code:
1. Loaded symbols into analyzer indexes (`class_index`, `function_index`, `file_index`)
2. Transitioned state to `INDEXED`
3. **BUT** never initialized `IndexingProgress` with cache metadata
4. `get_indexing_status` read from uninitialized `_progress` → defaulted to 0

**Code path:**
- `cpp_mcp_server.py` lines 707-741 in background indexing task
- Cache loads, state → INDEXED, but `state_manager.update_progress()` never called
- `state_manager.get_status_dict()` returns 0 for all counts when `_progress` is None

## Solution

Added progress initialization after successful cache load in `cpp_mcp_server.py` lines 720-735:

```python
if cache_valid:
    # Cache loaded successfully - skip indexing
    diagnostics.info(...)

    # CRITICAL FIX FOR ISSUE #15: Initialize progress with cache data
    from .state_manager import IndexingProgress
    from datetime import datetime

    # Create progress object from cached data
    total_files = len(analyzer.file_index)
    progress = IndexingProgress(
        total_files=total_files,
        indexed_files=total_files,  # All files loaded from cache
        failed_files=0,
        cache_hits=total_files,  # Everything from cache
        current_file=None,
        start_time=datetime.now(),
        estimated_completion=None
    )
    state_manager.update_progress(progress)

    state_manager.transition_to(AnalyzerState.INDEXED)
```

Now `get_indexing_status` reports correct counts immediately after `set_project_directory`.

## Testing

- ✅ All 580 unit tests pass with no regressions
- ✅ Logic verified: Progress initialized with cache data when cache loads
- ✅ Similar test exists: `test_get_indexing_status_immediately_after_set_project_directory`

## Related Issues & PRs

- **Fixes:** Issue #15 - Status reports zero files before refresh
- **Related:** Issue #10 (PR #64) - Similar symptom but different root cause (TU dict vs file_index)
- **Related:** Issue #1 (PR #66) - State initialization timing issue

## Files Changed

- `mcp_server/cpp_mcp_server.py` - Added progress initialization after cache load
- `docs/issues/005-status-zero-files-before-refresh.md` - Documented resolution
- `docs/MANUAL_TEST_OBSERVATIONS.md` - Updated issue status

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)