### PR TITLE
feat: Memory optimization Task 4.3 - Lazy call graph loading (~2 GB savings)

### DIFF
--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -136,9 +136,7 @@ def _process_file_worker(args_tuple):
         # Debug
         if call_sites:
             diagnostics.debug(f"Worker extracted {len(call_sites)} call sites from {file_path}")
-        diagnostics.debug(
-            f"Worker call_graph entries: {len(_worker_analyzer.call_graph_analyzer.call_graph)}"
-        )
+        # Phase 4: Task 4.3 - call_graph dict removed, only call_sites tracked in memory
         diagnostics.debug(
             f"Worker call_sites count: {len(_worker_analyzer.call_graph_analyzer.call_sites)}"
         )


### PR DESCRIPTION
## Summary

Implements **Task 4.3** from the Memory Optimization Plan: Lazy call graph loading by removing in-memory `call_graph` and `reverse_call_graph` dicts.

**Memory savings: ~2 GB** for large projects (17,911 files)

## Changes

### 1. CallGraphAnalyzer (call_graph.py)
- **Removed** `call_graph: Dict[str, Set[str]]` and `reverse_call_graph: Dict[str, Set[str]]` dicts
- **Updated** `add_call()` to stop populating removed dicts  
- **Modified** `find_callers()` and `find_callees()` to query **ONLY SQLite** (no in-memory fallback)
- **Updated** `remove_symbol()` to delete from SQLite via new `delete_call_sites_by_usr()` method
- **Simplified** `clear()` to only clear current session call_sites
- **Deprecated** `get_call_statistics()` and helper methods (not used anywhere)

### 2. SqliteCacheBackend (sqlite_cache_backend.py)
- **Added** `delete_call_sites_by_usr()` method for incremental refresh symbol removal

### 3. CppAnalyzer (cpp_analyzer.py)
- **Fixed** debug logging to not reference removed `call_graph` dict

## Memory Impact

**Before:**
- `call_graph`: ~1.23 GB (function USR → callees)
- `reverse_call_graph`: ~752 MB (function USR → callers)  
- **Total: ~2 GB**

**After:**
- Call graph data stored ONLY in SQLite `call_sites` table
- In-memory: only current session `call_sites` (cleared after save)
- **Savings: ~2 GB**

## Testing

✅ All 586 tests pass
✅ Call graph queries work correctly (find_callers, find_callees, call paths)
✅ Incremental refresh with symbol removal works
✅ No functional regressions

## Architecture

**Previous approach:**
- Call sites stored in both memory (dicts) and SQLite
- `find_callers()` / `find_callees()` checked memory first, then SQLite
- ~2 GB memory overhead

**New approach:**
- Call sites stored ONLY in SQLite  
- `find_callers()` / `find_callees()` query SQLite directly
- Current session call_sites cached in memory, then streamed to SQLite
- Memory used only for current indexing session

## Related Work

- **Phase 4, Task 4.1** (PR #95): Stream call sites to SQLite (~1.9 GB savings) - MERGED
- **Phase 4, Task 4.3** (this PR): Lazy call graph loading (~2 GB savings) - CURRENT
- **Phase 4, Task 4.2** (future): Stream symbols to SQLite (~2-3 GB savings) - PLANNED

## Documentation

Updated:
- CallGraphAnalyzer class docstrings
- Method docstrings explaining Phase 4 changes
- Code comments marking deprecated methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)