### PR TITLE
Preserve tool descriptions in mock runner explanations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test-installation: ## Test installation and basic functionality
 
 lint: ## Run linting checks (flake8)
 	@echo "$(BLUE)Running linting checks...$(NC)"
-	$(PYTHON) -m flake8 mcp_server/ scripts/ --exclude=scripts/archived/ --max-line-length=100 --ignore=E501,W503,E203
+	$(PYTHON) -m flake8 mcp_server/ scripts/ --exclude=scripts/archived/ --max-line-length=100 --select=C90,E,F,W --ignore=E501,W503,E203
 	@echo "$(GREEN)Linting complete!$(NC)"
 
 format: ## Format code with black

--- a/tests/test_mock_runner.py
+++ b/tests/test_mock_runner.py
@@ -5,8 +5,18 @@ from tools.mock_server.fixtures import FixtureStore
 class FakeClient:
     def __init__(self, responses):
         self._responses = list(responses)
+        self.calls = []
 
     def chat_completion(self, model, messages, tools, temperature=0, max_tokens=4096):
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "tools": tools,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+        )
         return self._responses.pop(0)
 
 
@@ -14,6 +24,42 @@ def test_system_prompt_bans_textual_tool_plans():
     assert "native tool call via the tool-calling API" in runner.SYSTEM_PROMPT
     assert "Do NOT write tool invocations as plain text" in runner.SYSTEM_PROMPT
     assert "tool_code" in runner.SYSTEM_PROMPT
+
+
+def test_request_explanation_includes_tool_descriptions_in_messages():
+    client = FakeClient(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "because",
+                        }
+                    }
+                ]
+            }
+        ]
+    )
+
+    explanation = runner._request_explanation(
+        client=client,
+        model="test-model",
+        messages=[{"role": "system", "content": "sys"}, {"role": "assistant", "content": "prior"}],
+        explanation_prompt="Why?",
+        tool_descriptions_text="find_incoming_calls:\nInbound description",
+    )
+
+    assert explanation == "because"
+    assert client.calls[0]["tools"] == []
+    assert client.calls[0]["messages"][-2] == {
+        "role": "system",
+        "content": (
+            "Original tool descriptions available during the tool-calling run:\n\n"
+            "find_incoming_calls:\nInbound description"
+        ),
+    }
+    assert client.calls[0]["messages"][-1] == {"role": "user", "content": "Why?"}
 
 
 def test_find_interesting_calls_mismatches_includes_mismatches_and_extra_calls():
@@ -105,12 +151,21 @@ def test_collect_posthoc_explanations_processes_calls_in_reverse_message_order(m
     ]
     calls = []
 
-    def fake_request(client, model, messages, explanation_prompt, temperature=0, max_tokens=2048):
+    def fake_request(
+        client,
+        model,
+        messages,
+        explanation_prompt,
+        tool_descriptions_text="",
+        temperature=0,
+        max_tokens=2048,
+    ):
         calls.append(
             {
                 "message_count": len(messages),
                 "last_role": messages[-1]["role"],
                 "prompt": explanation_prompt,
+                "tool_descriptions_text": tool_descriptions_text,
             }
         )
         return f"because-{len(calls)}"
@@ -124,11 +179,13 @@ def test_collect_posthoc_explanations_processes_calls_in_reverse_message_order(m
         step_results=step_results,
         recorded_calls=recorded_calls,
         overall_pass=False,
+        tool_descriptions_text="wrong_tool:\nA wrong tool",
         explain_scope="mismatches",
     )
 
     assert [item["message_count"] for item in calls] == [7, 4]
     assert all(item["last_role"] == "assistant" for item in calls)
+    assert all(item["tool_descriptions_text"] == "wrong_tool:\nA wrong tool" for item in calls)
     assert step_results[0]["llm_explanation"] == "because-2"
     assert recorded_calls[0]["explanation"]["response"] == "because-2"
     assert recorded_calls[1]["explanation"]["response"] == "because-1"
@@ -153,12 +210,21 @@ def test_collect_posthoc_explanations_explains_missing_step_without_tool_call(mo
     ]
     calls = []
 
-    def fake_request(client, model, messages, explanation_prompt, temperature=0, max_tokens=2048):
+    def fake_request(
+        client,
+        model,
+        messages,
+        explanation_prompt,
+        tool_descriptions_text="",
+        temperature=0,
+        max_tokens=2048,
+    ):
         calls.append(
             {
                 "message_count": len(messages),
                 "last_role": messages[-1]["role"],
                 "prompt": explanation_prompt,
+                "tool_descriptions_text": tool_descriptions_text,
             }
         )
         return "because-no-tool"
@@ -172,6 +238,7 @@ def test_collect_posthoc_explanations_explains_missing_step_without_tool_call(mo
         step_results=step_results,
         recorded_calls=[],
         overall_pass=False,
+        tool_descriptions_text="find_incoming_calls:\nInbound description",
         explain_scope="mismatches",
     )
 
@@ -185,6 +252,7 @@ def test_collect_posthoc_explanations_explains_missing_step_without_tool_call(mo
                 "of 'find_incoming_calls' tool description that made you decide against calling one."
                 "Be concise. Do not output any fluff."
             ),
+            "tool_descriptions_text": "find_incoming_calls:\nInbound description",
         }
     ]
     assert step_results[0]["llm_explanation"] == "because-no-tool"
@@ -227,7 +295,16 @@ def test_run_scenario_explain_all_adds_posthoc_explanation(monkeypatch):
     store = FixtureStore()
     store._defaults["find_symbols_by_pattern"] = {"results": []}
 
-    def fake_request(client, model, messages, explanation_prompt, temperature=0, max_tokens=2048):
+    def fake_request(
+        client,
+        model,
+        messages,
+        explanation_prompt,
+        tool_descriptions_text="",
+        temperature=0,
+        max_tokens=2048,
+    ):
+        assert "find_incoming_calls:\nInbound description" in tool_descriptions_text
         return "posthoc explanation"
 
     monkeypatch.setattr(runner, "_request_explanation", fake_request)
@@ -247,7 +324,16 @@ def test_run_scenario_explain_all_adds_posthoc_explanation(monkeypatch):
                 }
             ],
         },
-        openai_tools=[],
+        openai_tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "find_incoming_calls",
+                    "description": "Inbound description",
+                    "parameters": {},
+                },
+            }
+        ],
         store=store,
         system_prompt="system",
         explain_all=True,
@@ -280,12 +366,21 @@ def test_run_scenario_explain_all_explains_missing_tool_call(monkeypatch):
     )
     prompts = []
 
-    def fake_request(client, model, messages, explanation_prompt, temperature=0, max_tokens=2048):
+    def fake_request(
+        client,
+        model,
+        messages,
+        explanation_prompt,
+        tool_descriptions_text="",
+        temperature=0,
+        max_tokens=2048,
+    ):
         prompts.append(
             {
                 "message_count": len(messages),
                 "last_role": messages[-1]["role"],
                 "prompt": explanation_prompt,
+                "tool_descriptions_text": tool_descriptions_text,
             }
         )
         return "posthoc no-tool explanation"
@@ -307,7 +402,16 @@ def test_run_scenario_explain_all_explains_missing_tool_call(monkeypatch):
                 }
             ],
         },
-        openai_tools=[],
+        openai_tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "find_incoming_calls",
+                    "description": "Inbound description",
+                    "parameters": {},
+                },
+            }
+        ],
         store=FixtureStore(),
         system_prompt="system",
         explain_all=True,
@@ -329,5 +433,6 @@ def test_run_scenario_explain_all_explains_missing_tool_call(monkeypatch):
                 "of 'find_incoming_calls' tool description that made you decide against calling one."
                 "Be concise. Do not output any fluff."
             ),
+            "tool_descriptions_text": "find_incoming_calls:\nInbound description",
         }
     ]

--- a/tools/mock_server/runner.py
+++ b/tools/mock_server/runner.py
@@ -163,6 +163,21 @@ def mcp_tools_to_openai(tools: list) -> List[Dict[str, Any]]:
     return result
 
 
+def format_tool_descriptions_for_explanations(openai_tools: List[Dict[str, Any]]) -> str:
+    """Render tool descriptions as plain text for explanation-only follow-ups."""
+    sections: List[str] = []
+
+    for tool in openai_tools:
+        function = tool.get("function", {})
+        name = function.get("name")
+        description = function.get("description")
+        if not name or not description:
+            continue
+        sections.append(f"{name}:\n{description}")
+
+    return "\n\n".join(sections)
+
+
 # ---------------------------------------------------------------------------
 # LM Studio OpenAI-compat client
 # ---------------------------------------------------------------------------
@@ -565,11 +580,22 @@ def _request_explanation(
     model: str,
     messages: List[Dict[str, Any]],
     explanation_prompt: str,
+    tool_descriptions_text: str = "",
     temperature: float = 0,
     max_tokens: int = 2048,
 ) -> Optional[str]:
     """Ask the LLM to explain its tool choice. Returns explanation text."""
     explain_messages = list(messages)
+    if tool_descriptions_text:
+        explain_messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Original tool descriptions available during the tool-calling run:\n\n"
+                    f"{tool_descriptions_text}"
+                ),
+            }
+        )
     explain_messages.append({"role": "user", "content": explanation_prompt})
 
     try:
@@ -668,6 +694,7 @@ def _collect_posthoc_explanations(
     step_results: List[Dict[str, Any]],
     recorded_calls: List[Dict[str, Any]],
     overall_pass: bool,
+    tool_descriptions_text: str = "",
     explain_scope: str = "mismatches",
     temperature: float = 0,
     max_tokens: int = 2048,
@@ -706,6 +733,7 @@ def _collect_posthoc_explanations(
             model=model,
             messages=truncated_messages,
             explanation_prompt=prompt,
+            tool_descriptions_text=tool_descriptions_text,
             temperature=temperature,
             max_tokens=max_tokens,
         )
@@ -763,6 +791,7 @@ def run_scenario(
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": scenario["query"]},
     ]
+    tool_descriptions_text = format_tool_descriptions_for_explanations(openai_tools)
 
     expected_steps = scenario.get("expected_steps", [])
     recorded_calls: List[Dict[str, Any]] = []
@@ -853,6 +882,7 @@ def run_scenario(
                         model,
                         messages,
                         prompt,
+                        tool_descriptions_text=tool_descriptions_text,
                         temperature=temperature,
                         max_tokens=2048,
                     )
@@ -917,6 +947,7 @@ def run_scenario(
                             model,
                             messages,
                             prompt,
+                            tool_descriptions_text=tool_descriptions_text,
                             temperature=temperature,
                             max_tokens=2048,
                         )
@@ -962,6 +993,7 @@ def run_scenario(
                                 model,
                                 messages,
                                 prompt,
+                                tool_descriptions_text=tool_descriptions_text,
                                 temperature=temperature,
                                 max_tokens=2048,
                             )
@@ -979,6 +1011,7 @@ def run_scenario(
                         model,
                         messages,
                         prompt,
+                        tool_descriptions_text=tool_descriptions_text,
                         temperature=temperature,
                         max_tokens=2048,
                     )
@@ -1050,6 +1083,7 @@ def run_scenario(
             step_results=step_results,
             recorded_calls=recorded_calls,
             overall_pass=overall_pass,
+            tool_descriptions_text=tool_descriptions_text,
             explain_scope=explain_scope,
             temperature=temperature,
             max_tokens=2048,


### PR DESCRIPTION
## Summary
- preserve original tool descriptions in mock-runner explanation requests even when tools are disabled for the reflection turn
- add runner tests that verify explanation requests receive tool-description context
- constrain `make lint` to core flake8 code families so local hooks stay aligned with GitHub CI even if extra flake8 plugins are installed in the venv

## Validation
- `mcp_env/bin/pytest tests/test_mock_runner.py`
- pre-push hook: `make test`, `make format-check`, `make lint`