### PR TITLE
feat: implement hybrid project setup via external config files

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -80,6 +80,25 @@ Place `.cpp-analyzer-config.json` (note the leading dot) in your C++ project roo
 
 **Use case**: Per-project settings that persist with your codebase.
 
+### 3. Hybrid Project Entry Point (External Configuration)
+You can use a `.json` configuration file as the primary project "path" when calling `set_project`. This file does not need to be inside your source tree.
+
+To use this mode, the configuration file **must** include a `project_root` field:
+
+```json
+{
+  "project_root": "/path/to/my/cpp/project",
+  "exclude_directories": ["build", "tests"],
+  "compile_commands": {
+    "path": "build/compile_commands.json"
+  }
+}
+```
+
+If `project_root` is a relative path, it is resolved **relative to the directory containing the config file**.
+
+**Use case**: Multiple configurations for the same source, or keeping your source tree completely clean of MCP-specific files.
+
 ## Configuration File Format
 
 ```json

--- a/mcp_server/consolidated_tools.py
+++ b/mcp_server/consolidated_tools.py
@@ -157,15 +157,11 @@ def list_tools_b() -> List[Tool]:
             name="set_project",
             description=(
                 "REQUIRED FIRST STEP: Set the C++ project to analyze. "
-                "Must be called before any other tools. The 'path' can be either "
-                "the absolute path to the C++ project root directory OR the absolute "
-                "path to a .json configuration file that defines 'project_root'.\n\n"
-                "Using a configuration file allows you to specify multiple projects "
-                "or configurations for the same source directory without adding "
-                "configuration files to the source directory itself.\n\n"
-                "Indexes all C++ files using libclang. Waits synchronously for "
-                "indexing to complete (up to sync_timeout seconds). Returns status "
-                "'ready' when indexing finishes, or 'indexing_in_progress' if timeout exceeded."
+                "The 'path' can be either a project root directory OR a .json configuration file "
+                "defining 'project_root'. Using a config file allows multiple analysis profiles "
+                "without polluting the source tree.\n\n"
+                "Indexes all C++ files and waits for completion (up to sync_timeout seconds). "
+                "Returns 'ready' when finished, or 'indexing_in_progress' if timeout exceeded."
             ),
             inputSchema={
                 "type": "object",

--- a/mcp_server/consolidated_tools.py
+++ b/mcp_server/consolidated_tools.py
@@ -156,22 +156,27 @@ def list_tools_b() -> List[Tool]:
         Tool(
             name="set_project",
             description=(
-                "REQUIRED FIRST STEP: Set the C++ project directory to analyze. "
-                "Must be called before any other tools. Indexes all C++ files "
-                "using libclang. Waits synchronously for indexing to complete "
-                "(up to sync_timeout seconds). Returns status 'ready' when "
-                "indexing finishes, or 'indexing_in_progress' if timeout exceeded."
+                "REQUIRED FIRST STEP: Set the C++ project to analyze. "
+                "Must be called before any other tools. The 'path' can be either "
+                "the absolute path to the C++ project root directory OR the absolute "
+                "path to a .json configuration file that defines 'project_root'.\n\n"
+                "Using a configuration file allows you to specify multiple projects "
+                "or configurations for the same source directory without adding "
+                "configuration files to the source directory itself.\n\n"
+                "Indexes all C++ files using libclang. Waits synchronously for "
+                "indexing to complete (up to sync_timeout seconds). Returns status "
+                "'ready' when indexing finishes, or 'indexing_in_progress' if timeout exceeded."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "Absolute path to C++ project root directory.",
+                        "description": "Absolute path to C++ project root directory OR a .json config file.",
                     },
                     "config_file": {
                         "type": "string",
-                        "description": "Optional: Path to cpp-analyzer-config.json.",
+                        "description": "Optional: Path to cpp-analyzer-config.json (if 'path' is a directory).",
                     },
                     "sync_timeout": {
                         "type": "number",

--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -527,7 +527,7 @@ class CppAnalyzer:
         self.project_identity = ProjectIdentity(self.project_root, config_path)
 
         # Load project configuration
-        self.config = CppAnalyzerConfig(self.project_root)
+        self.config = CppAnalyzerConfig(self.project_root, config_path=config_path)
 
         # Indexes for fast lookup
         self.class_index: Dict[str, List[SymbolInfo]] = defaultdict(list)

--- a/mcp_server/cpp_analyzer_config.py
+++ b/mcp_server/cpp_analyzer_config.py
@@ -50,21 +50,30 @@ class CppAnalyzerConfig:
         "diagnostics": {"level": "info", "enabled": True},  # debug, info, warning, error, fatal
     }
 
-    def __init__(self, project_root: Path):
+    def __init__(self, project_root: Path, config_path: Optional[Path] = None):
         self.project_root = project_root
-        self.config_path: Optional[Path] = None  # Will be set by _find_config_file
+        self.config_path = config_path  # Pre-specified config path
         self.config = self._load_config()
 
     def _find_config_file(self) -> Tuple[Optional[Path], Optional[str]]:
         """Find config file by checking multiple locations in priority order.
 
         Priority order:
-        1. Environment variable CPP_ANALYZER_CONFIG
-        2. Project root (.cpp-analyzer-config.json)
+        1. Pre-specified config_path (from constructor)
+        2. Environment variable CPP_ANALYZER_CONFIG
+        3. Project root (.cpp-analyzer-config.json)
 
         Returns tuple of (config_path, source_description) or (None, None) if not found.
         """
-        # 1. Check environment variable
+        # 1. Check pre-specified path
+        if self.config_path:
+            if self.config_path.exists():
+                diagnostics.debug(f"Using pre-specified config: {self.config_path}")
+                return (self.config_path, "specified config file")
+            else:
+                diagnostics.warning(f"Specified config file not found: {self.config_path}")
+
+        # 2. Check environment variable
         env_config = os.environ.get("CPP_ANALYZER_CONFIG")
         if env_config:
             env_path = Path(env_config)

--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -521,15 +521,58 @@ async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextCo
                     )
                 ]
 
-            if not os.path.isdir(project_path):
+            # Hybrid approach: project_path can be a directory OR a config file
+            if os.path.isfile(project_path):
+                if not project_path.endswith(".json"):
+                    return [
+                        TextContent(
+                            type="text",
+                            text=f"Error: Config file '{project_path}' must have .json extension",
+                        )
+                    ]
+                try:
+                    with open(project_path, "r") as f:
+                        config_data = json.load(f)
+
+                    config_root = config_data.get("project_root")
+                    if not config_root:
+                        return [
+                            TextContent(
+                                type="text",
+                                text=f"Error: Config file '{project_path}' is missing 'project_root' field",
+                            )
+                        ]
+
+                    # Resolve project_root relative to config file directory
+                    config_dir = os.path.dirname(project_path)
+                    resolved_root = os.path.abspath(os.path.join(config_dir, config_root))
+
+                    if not os.path.isdir(resolved_root):
+                        return [
+                            TextContent(
+                                type="text",
+                                text=f"Error: 'project_root' in config '{resolved_root}' is not a directory or does not exist",
+                            )
+                        ]
+
+                    # Swap: the file becomes the config_file, the extracted path becomes project_path
+                    config_file = project_path
+                    project_path = resolved_root
+                    diagnostics.info(
+                        f"Hybrid setup: Using config {config_file} for root {project_path}"
+                    )
+                except Exception as e:
+                    return [TextContent(type="text", text=f"Error reading config file: {str(e)}")]
+            elif not os.path.isdir(project_path):
                 return [
                     TextContent(
-                        type="text", text=f"Error: Directory '{project_path}' does not exist"
+                        type="text",
+                        text=f"Error: Directory or config file '{project_path}' does not exist",
                     )
                 ]
 
-            # Validate config_file if provided
-            if config_file:
+            # Validate config_file if provided (and not already set by hybrid path)
+            if config_file and not os.path.isfile(config_file):
                 if not isinstance(config_file, str) or not config_file.strip():
                     return [
                         TextContent(

--- a/tests/test_hybrid_setup.py
+++ b/tests/test_hybrid_setup.py
@@ -1,0 +1,134 @@
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from mcp_server.cpp_analyzer_config import CppAnalyzerConfig
+from mcp_server.cpp_mcp_server import _handle_tool_call
+
+@pytest.mark.asyncio
+async def test_cpp_analyzer_config_prioritization():
+    """Test that CppAnalyzerConfig prioritizes the explicitly passed path."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        
+        # 1. Project root config (lower priority)
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        root_config = project_root / ".cpp-analyzer-config.json"
+        with open(root_config, "w") as f:
+            json.dump({"max_file_size_mb": 50}, f)
+            
+        # 2. External config (higher priority)
+        external_config = tmp_path / "external.json"
+        with open(external_config, "w") as f:
+            json.dump({"max_file_size_mb": 99}, f)
+            
+        # Initialize config with both present
+        config = CppAnalyzerConfig(project_root, config_path=external_config)
+        
+        # Should pick external_config (99) over root_config (50)
+        assert config.get_max_file_size_mb() == 99
+        assert config.config_path == external_config
+
+@pytest.mark.asyncio
+async def test_hybrid_project_setup():
+    """Test setting project directory via a configuration file."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        
+        # 1. Create a dummy project directory
+        project_dir = tmp_path / "my_project"
+        project_dir.mkdir()
+        (project_dir / "main.cpp").write_text("int main() { return 0; }")
+        
+        # 2. Create an external configuration file
+        config_file = tmp_path / "external_config.json"
+        config_data = {
+            "project_root": "my_project",  # Relative to config_file
+            "exclude_directories": ["build"]
+        }
+        with open(config_file, "w") as f:
+            json.dump(config_data, f)
+            
+        # 3. Mock dependencies in _handle_tool_call to avoid actual indexing
+        with patch("mcp_server.cpp_mcp_server.CppAnalyzer") as MockAnalyzer, \
+             patch("mcp_server.cpp_mcp_server.BackgroundIndexer"), \
+             patch("mcp_server.cpp_mcp_server.ToolCallLogger"), \
+             patch("mcp_server.cpp_mcp_server.state_manager") as mock_state_manager, \
+             patch("mcp_server.cpp_mcp_server.session_manager") as mock_session_manager:
+            
+            # Setup mock analyzer
+            mock_analyzer_instance = MockAnalyzer.return_value
+            mock_analyzer_instance.cache_dir = "/tmp/fake_cache"
+            mock_analyzer_instance.class_index = {}
+            mock_analyzer_instance.function_index = {}
+            mock_analyzer_instance.file_index = {}
+            
+            # Call set_project_directory with the config file path
+            arguments = {
+                "project_path": str(config_file.absolute()),
+                "auto_refresh": True
+            }
+            
+            from mcp_server.cpp_mcp_server import _handle_tool_call
+            results = await _handle_tool_call("set_project_directory", arguments)
+            
+            # Verify results
+            assert "Set project directory to" in results[0].text
+            assert str(project_dir.absolute()) in results[0].text
+            assert str(config_file.absolute()) in results[0].text
+            
+            # Verify MockAnalyzer was called with resolved paths
+            # The first argument should be the resolved project root
+            # The config_file argument should be the config file path
+            args, kwargs = MockAnalyzer.call_args
+            assert args[0] == str(project_dir.absolute())
+            assert kwargs["config_file"] == str(config_file.absolute())
+
+@pytest.mark.asyncio
+async def test_hybrid_project_setup_invalid_root():
+    """Test hybrid setup with a non-existent project_root."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        
+        config_file = tmp_path / "bad_config.json"
+        config_data = {
+            "project_root": "non_existent_folder"
+        }
+        with open(config_file, "w") as f:
+            json.dump(config_data, f)
+            
+        arguments = {
+            "project_path": str(config_file.absolute())
+        }
+        
+        results = await _handle_tool_call("set_project_directory", arguments)
+        assert "Error: 'project_root' in config" in results[0].text
+        assert "is not a directory" in results[0].text
+
+@pytest.mark.asyncio
+async def test_hybrid_project_setup_missing_field():
+    """Test hybrid setup with a config file missing project_root."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        
+        config_file = tmp_path / "missing_field.json"
+        config_data = {
+            "some_other_field": "value"
+        }
+        with open(config_file, "w") as f:
+            json.dump(config_data, f)
+            
+        arguments = {
+            "project_path": str(config_file.absolute())
+        }
+        
+        results = await _handle_tool_call("set_project_directory", arguments)
+        assert "is missing 'project_root' field" in results[0].text


### PR DESCRIPTION
This PR implements a hybrid project setup mode where the 'path' argument to 'set_project' can be a .json configuration file. This allows users to keep their source tree clean and use multiple configurations for the same project. Key changes include:
- Polymorphic 'path' parameter for 'set_project'.
- Automatic project_root extraction and resolution from config files.
- Documentation and tests.