### PR TITLE
Align libclang setup and add compile environment diagnostics

### DIFF
--- a/mcp_server/compile_commands_manager.py
+++ b/mcp_server/compile_commands_manager.py
@@ -863,6 +863,7 @@ class CompileCommandsManager:
     def get_stats(self) -> Dict[str, Any]:
         """Get statistics about the compile commands manager."""
         with self.cache_lock:
+            fallback_profile = self._extract_arg_insights(self.fallback_args)
             return {
                 "enabled": self.enabled,
                 "compile_commands_count": len(self.compile_commands),
@@ -871,7 +872,60 @@ class CompileCommandsManager:
                 "fallback_enabled": self.fallback_to_hardcoded,
                 "last_modified": self.last_modified,
                 "compile_commands_path": str(self.project_root / self.compile_commands_path),
+                "clang_resource_dir": self.clang_resource_dir,
+                "fallback_cxx_standards": fallback_profile["cxx_standards"],
+                "fallback_system_include_dirs": fallback_profile["system_include_dirs"],
             }
+
+    def _extract_arg_insights(self, args: List[str]) -> Dict[str, List[str]]:
+        """Extract concise diagnostics from compile arguments."""
+        standards: List[str] = []
+        system_includes: List[str] = []
+
+        i = 0
+        while i < len(args):
+            arg = args[i]
+            if arg.startswith("-std="):
+                standards.append(arg[len("-std=") :])
+            elif arg == "-std" and i + 1 < len(args):
+                standards.append(args[i + 1])
+                i += 1
+            elif arg.startswith("-isystem="):
+                system_includes.append(arg[len("-isystem=") :])
+            elif arg == "-isystem" and i + 1 < len(args):
+                system_includes.append(args[i + 1])
+                i += 1
+            i += 1
+
+        # De-duplicate while preserving order
+        unique_standards = list(dict.fromkeys(standards))
+        unique_system_includes = list(dict.fromkeys(system_includes))
+        return {
+            "cxx_standards": unique_standards,
+            "system_include_dirs": unique_system_includes,
+        }
+
+    def get_compile_arg_profile(self, file_path: Path) -> Dict[str, Any]:
+        """Return compile argument profile for a specific source file."""
+        compile_args = self.get_compile_args(file_path)
+        if compile_args is not None:
+            args_source = "compile_commands"
+            final_args = compile_args
+        elif self.fallback_to_hardcoded:
+            args_source = "fallback"
+            final_args = self.fallback_args.copy()
+        else:
+            args_source = "none"
+            final_args = []
+
+        insights = self._extract_arg_insights(final_args)
+        return {
+            "file": str(file_path),
+            "args_source": args_source,
+            "cxx_standards": insights["cxx_standards"],
+            "system_include_dirs": insights["system_include_dirs"],
+            "clang_resource_dir": self.clang_resource_dir,
+        }
 
     def is_file_supported(self, file_path: Path) -> bool:
         """Check if a file has compile commands available."""

--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -3392,6 +3392,7 @@ class CppAnalyzer:
             return 0
 
         diagnostics.debug(f"Found {len(files)} C++ files to index")
+        self._log_compilation_environment(files)
 
         # Show detailed progress
         indexed_count = 0
@@ -4089,6 +4090,35 @@ class CppAnalyzer:
             return {"enabled": False}
 
         return self.compile_commands_manager.get_stats()
+
+    def _log_compilation_environment(self, files: List[str]) -> None:
+        """Log libclang compilation environment for diagnostics."""
+        if self.compile_commands_manager is None:
+            return
+
+        compile_stats = self.compile_commands_manager.get_stats()
+        diagnostics.info(
+            "Compilation environment: "
+            f"compile_commands_enabled={compile_stats.get('enabled')} "
+            f"compile_commands_count={compile_stats.get('compile_commands_count')} "
+            f"clang_resource_dir={compile_stats.get('clang_resource_dir')} "
+            f"fallback_cxx_standards={compile_stats.get('fallback_cxx_standards')} "
+            f"fallback_system_include_dirs={compile_stats.get('fallback_system_include_dirs')}"
+        )
+
+        if not files:
+            return
+
+        sample_count = min(3, len(files))
+        for source_file in files[:sample_count]:
+            profile = self.compile_commands_manager.get_compile_arg_profile(Path(source_file))
+            diagnostics.info(
+                "Compile args profile: "
+                f"file={profile.get('file')} "
+                f"source={profile.get('args_source')} "
+                f"cxx_standards={profile.get('cxx_standards')} "
+                f"system_include_dirs={profile.get('system_include_dirs')}"
+            )
 
     def refresh_if_needed(self, progress_callback: Optional[Callable] = None) -> int:
         """

--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -18,7 +18,7 @@ except ImportError:
     from . import diagnostics
 
 try:
-    from clang.cindex import Config
+    from clang.cindex import Config  # noqa: F401
 except ImportError:
     diagnostics.fatal("clang package not found. Install with: pip install libclang")
     sys.exit(1)
@@ -26,184 +26,15 @@ except ImportError:
 from mcp.server import Server
 from mcp.types import TextContent, Tool
 
+try:
+    from mcp_server.libclang_setup import configure_libclang, get_libclang_runtime_info
+except ImportError:
+    from libclang_setup import configure_libclang, get_libclang_runtime_info  # type: ignore[no-redef]
+
 
 def find_and_configure_libclang():
-    """Find and configure libclang library using hybrid discovery approach.
-
-    Search order (FIX FOR ISSUE #003):
-    1. LIBCLANG_PATH environment variable (user override)
-    2. Smart discovery (xcrun for Xcode CLT on macOS)
-    3. System-installed libraries (prefer system over bundled)
-    4. Bundled libraries (fallback)
-
-    See: docs/MACOS_LIBCLANG_DISCOVERY.md
-    """
-    # Guard: if libclang is already loaded, no need to reconfigure.
-    # This handles the double-import case where the module is first loaded as
-    # __main__ (via python -m) and then reimported under its package name
-    # (from mcp_server.cpp_mcp_server import ...).  The second import would
-    # otherwise call Config.set_library_file() after Config.loaded is True,
-    # raising "library file must be set before ...".
-    if Config.loaded:
-        return True
-
-    import glob
-    import platform
-    import shutil
-    import subprocess
-
-    system = platform.system()
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    # Go up one directory to find lib folder (since we're in mcp_server subfolder)
-    parent_dir = os.path.dirname(script_dir)
-
-    # ========================================================================
-    # STEP 1: Check environment variables (user override)
-    # ========================================================================
-    # 1a. LIBCLANG_PATH (can be file OR directory)
-    env_path = os.environ.get("LIBCLANG_PATH")
-    if env_path and os.path.exists(env_path):
-        if os.path.isdir(env_path):
-            diagnostics.info(f"Using libclang search path from LIBCLANG_PATH: {env_path}")
-            Config.set_library_path(env_path)
-        else:
-            diagnostics.info(f"Using libclang from LIBCLANG_PATH: {env_path}")
-            Config.set_library_file(env_path)
-        return True
-    elif env_path:
-        diagnostics.warning(f"LIBCLANG_PATH set but path not found: {env_path}")
-
-    # 1b. CLANG_LIBRARY_PATH (directory)
-    lib_path = os.environ.get("CLANG_LIBRARY_PATH")
-    if lib_path and os.path.exists(lib_path) and os.path.isdir(lib_path):
-        diagnostics.info(f"Using libclang search path from CLANG_LIBRARY_PATH: {lib_path}")
-        Config.set_library_path(lib_path)
-        return True
-    elif lib_path:
-        diagnostics.warning(f"CLANG_LIBRARY_PATH set but directory not found: {lib_path}")
-
-    # ========================================================================
-    # STEP 2: Smart discovery (macOS only for now)
-    # ========================================================================
-    if system == "Darwin":
-        # Try xcrun to find Xcode Command Line Tools libclang
-        try:
-            result = subprocess.run(
-                ["xcrun", "--find", "clang"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                clang_path = result.stdout.strip()
-                # clang is at .../usr/bin/clang, libclang.dylib is at .../usr/lib/libclang.dylib
-                clang_dir = os.path.dirname(os.path.dirname(clang_path))  # Go up 2 levels
-                libclang_path = os.path.join(clang_dir, "lib", "libclang.dylib")
-                if os.path.exists(libclang_path):
-                    diagnostics.info(f"Found libclang via xcrun: {libclang_path}")
-                    Config.set_library_file(libclang_path)
-                    return True
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass  # xcrun not available or timed out
-
-    # ========================================================================
-    # STEP 3: Search system-installed libraries (platform-specific)
-    # ========================================================================
-    diagnostics.info("Searching for system-installed libclang...")
-
-    # Platform-specific library names and search patterns
-    PLATFORM_CONFIG = {
-        "Windows": {
-            "lib_names": ["libclang.dll", "clang.dll"],
-            "system_paths": [
-                r"C:\Program Files\LLVM\bin",
-                r"C:\Program Files (x86)\LLVM\bin",
-                r"C:\vcpkg\installed\x64-windows\bin",
-                r"C:\vcpkg\installed\x86-windows\bin",
-                r"C:\ProgramData\Anaconda3\Library\bin",
-            ],
-            "llvm_config_query": "--libdir",
-        },
-        "Darwin": {
-            "lib_names": ["libclang.dylib"],
-            "system_paths": [
-                "/Library/Developer/CommandLineTools/usr/lib",
-                "/opt/homebrew/Cellar/llvm/*/lib",
-                "/opt/homebrew/Cellar/llvm@*/*/lib",
-                "/opt/homebrew/lib",
-                "/usr/local/Cellar/llvm/*/lib",
-                "/usr/local/Cellar/llvm@*/*/lib",
-                "/usr/local/lib",
-                "/opt/local/libexec/llvm-*/lib",
-                "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib",
-            ],
-            "llvm_config_query": "--libdir",
-        },
-        "Linux": {
-            "lib_names": ["libclang.so.1", "libclang.so"],
-            "system_paths": [
-                "/usr/lib/llvm-*/lib",
-                "/usr/lib/x86_64-linux-gnu",
-                "/usr/lib",
-            ],
-            "llvm_config_query": "--libdir",
-        },
-    }
-
-    config = PLATFORM_CONFIG.get(system, PLATFORM_CONFIG["Linux"])
-    lib_names = config["lib_names"]
-    system_base_paths = list(config["system_paths"])
-
-    # Try to find in system PATH using llvm-config
-    llvm_config = shutil.which("llvm-config")
-    if llvm_config:
-        try:
-            result = subprocess.run(
-                [llvm_config, config["llvm_config_query"]],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                lib_dir = result.stdout.strip()
-                if os.path.exists(lib_dir):
-                    system_base_paths.insert(0, lib_dir)
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
-
-    # Try each system path and library name combination
-    for base_path in system_base_paths:
-        for lib_name in lib_names:
-            path_pattern = os.path.join(base_path, lib_name)
-            if "*" in path_pattern:
-                matches = sorted(glob.glob(path_pattern), reverse=True)
-                paths_to_check = matches
-            else:
-                paths_to_check = [path_pattern]
-
-            for path in paths_to_check:
-                if os.path.exists(path):
-                    diagnostics.info(f"Found system libclang at: {path}")
-                    Config.set_library_file(path)
-                    return True
-
-    # ========================================================================
-    # STEP 4: Try bundled libraries (fallback)
-    # ========================================================================
-    diagnostics.info("No system libclang found, trying bundled libraries...")
-
-    # Platform to bundled subdir mapping
-    BUNDLED_SUBDIRS = {"Windows": "windows", "Darwin": "macos", "Linux": "linux"}
-    platform_subdir = BUNDLED_SUBDIRS.get(system, "linux")
-
-    for lib_name in lib_names:
-        path = os.path.join(parent_dir, "lib", platform_subdir, "lib", lib_name)
-        if os.path.exists(path):
-            diagnostics.info(f"Using bundled libclang at: {path}")
-            Config.set_library_file(path)
-            return True
-
-    return False
+    """Backwards-compatible wrapper around shared libclang setup."""
+    return configure_libclang()
 
 
 # Try to find and configure libclang
@@ -214,6 +45,8 @@ if not find_and_configure_libclang():
     diagnostics.fatal("  macOS: brew install llvm")
     diagnostics.fatal("  Linux: sudo apt install libclang-dev")
     sys.exit(1)
+
+diagnostics.info(f"libclang runtime config: {get_libclang_runtime_info()}")
 
 # Import the Python analyzer and state manager
 try:

--- a/mcp_server/libclang_setup.py
+++ b/mcp_server/libclang_setup.py
@@ -1,0 +1,163 @@
+"""Shared libclang discovery/configuration for MCP server and scripts."""
+
+import os
+
+from clang.cindex import Config
+
+# Handle both package and script imports
+try:
+    from . import diagnostics
+except ImportError:
+    import diagnostics  # type: ignore[no-redef]
+
+
+def configure_libclang() -> bool:
+    """Find and configure libclang library using hybrid discovery approach."""
+    # If already loaded, keep current configuration.
+    if Config.loaded:
+        diagnostics.info("libclang already loaded; keeping existing configuration")
+        return True
+
+    import glob
+    import platform
+    import shutil
+    import subprocess
+
+    system = platform.system()
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    parent_dir = os.path.dirname(script_dir)
+
+    env_path = os.environ.get("LIBCLANG_PATH")
+    if env_path and os.path.exists(env_path):
+        if os.path.isdir(env_path):
+            diagnostics.info(f"Using libclang search path from LIBCLANG_PATH: {env_path}")
+            Config.set_library_path(env_path)
+        else:
+            diagnostics.info(f"Using libclang from LIBCLANG_PATH: {env_path}")
+            Config.set_library_file(env_path)
+        return True
+    elif env_path:
+        diagnostics.warning(f"LIBCLANG_PATH set but path not found: {env_path}")
+
+    lib_path = os.environ.get("CLANG_LIBRARY_PATH")
+    if lib_path and os.path.exists(lib_path) and os.path.isdir(lib_path):
+        diagnostics.info(f"Using libclang search path from CLANG_LIBRARY_PATH: {lib_path}")
+        Config.set_library_path(lib_path)
+        return True
+    elif lib_path:
+        diagnostics.warning(f"CLANG_LIBRARY_PATH set but directory not found: {lib_path}")
+
+    if system == "Darwin":
+        try:
+            result = subprocess.run(
+                ["xcrun", "--find", "clang"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                clang_path = result.stdout.strip()
+                clang_dir = os.path.dirname(os.path.dirname(clang_path))
+                libclang_path = os.path.join(clang_dir, "lib", "libclang.dylib")
+                if os.path.exists(libclang_path):
+                    diagnostics.info(f"Found libclang via xcrun: {libclang_path}")
+                    Config.set_library_file(libclang_path)
+                    return True
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    diagnostics.info("Searching for system-installed libclang...")
+
+    platform_config = {
+        "Windows": {
+            "lib_names": ["libclang.dll", "clang.dll"],
+            "system_paths": [
+                r"C:\Program Files\LLVM\bin",
+                r"C:\Program Files (x86)\LLVM\bin",
+                r"C:\vcpkg\installed\x64-windows\bin",
+                r"C:\vcpkg\installed\x86-windows\bin",
+                r"C:\ProgramData\Anaconda3\Library\bin",
+            ],
+            "llvm_config_query": "--libdir",
+        },
+        "Darwin": {
+            "lib_names": ["libclang.dylib"],
+            "system_paths": [
+                "/Library/Developer/CommandLineTools/usr/lib",
+                "/opt/homebrew/Cellar/llvm/*/lib",
+                "/opt/homebrew/Cellar/llvm@*/*/lib",
+                "/opt/homebrew/lib",
+                "/usr/local/Cellar/llvm/*/lib",
+                "/usr/local/Cellar/llvm@*/*/lib",
+                "/usr/local/lib",
+                "/opt/local/libexec/llvm-*/lib",
+                "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+            ],
+            "llvm_config_query": "--libdir",
+        },
+        "Linux": {
+            "lib_names": ["libclang.so.1", "libclang.so"],
+            "system_paths": [
+                "/usr/lib/llvm-*/lib",
+                "/usr/lib/x86_64-linux-gnu",
+                "/usr/lib",
+            ],
+            "llvm_config_query": "--libdir",
+        },
+    }
+
+    config = platform_config.get(system, platform_config["Linux"])
+    lib_names = config["lib_names"]
+    system_base_paths = list(config["system_paths"])
+
+    llvm_config = shutil.which("llvm-config")
+    if llvm_config:
+        try:
+            result = subprocess.run(
+                [llvm_config, config["llvm_config_query"]],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                lib_dir = result.stdout.strip()
+                if os.path.exists(lib_dir):
+                    system_base_paths.insert(0, lib_dir)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    for base_path in system_base_paths:
+        for lib_name in lib_names:
+            path_pattern = os.path.join(base_path, lib_name)
+            if "*" in path_pattern:
+                paths_to_check = sorted(glob.glob(path_pattern), reverse=True)
+            else:
+                paths_to_check = [path_pattern]
+
+            for path in paths_to_check:
+                if os.path.exists(path):
+                    diagnostics.info(f"Found system libclang at: {path}")
+                    Config.set_library_file(path)
+                    return True
+
+    diagnostics.info("No system libclang found, trying bundled libraries...")
+    bundled_subdirs = {"Windows": "windows", "Darwin": "macos", "Linux": "linux"}
+    platform_subdir = bundled_subdirs.get(system, "linux")
+
+    for lib_name in lib_names:
+        path = os.path.join(parent_dir, "lib", platform_subdir, "lib", lib_name)
+        if os.path.exists(path):
+            diagnostics.info(f"Using bundled libclang at: {path}")
+            Config.set_library_file(path)
+            return True
+
+    return False
+
+
+def get_libclang_runtime_info() -> dict:
+    """Return the current libclang runtime settings for diagnostics."""
+    return {
+        "loaded": bool(Config.loaded),
+        "library_file": getattr(Config, "library_file", None),
+        "library_path": getattr(Config, "library_path", None),
+    }

--- a/scripts/test_mcp_console.py
+++ b/scripts/test_mcp_console.py
@@ -23,7 +23,15 @@ _analyzer = None
 def test_mcp_server(project_path: str):
     """Test the MCP server with a real codebase"""
 
-    # Import the analyzer
+    # Configure libclang exactly like production MCP server
+    from mcp_server.libclang_setup import configure_libclang, get_libclang_runtime_info
+
+    if not configure_libclang():
+        print("Error: Could not find libclang library")
+        return
+    print(f"[OK] libclang runtime config: {get_libclang_runtime_info()}")
+
+    # Import the analyzer after libclang setup
     from mcp_server.cpp_analyzer import CppAnalyzer
 
     print("=" * 60)
@@ -71,6 +79,19 @@ def test_mcp_server(project_path: str):
     print("[OK] Server status:")
     for key, value in status.items():
         print(f"   {key}: {value}")
+
+    # 3.1. Show compile args profile for a sample file
+    if analyzer.compile_commands_manager:
+        source_files = analyzer.compile_commands_manager.get_all_files()
+        if source_files:
+            profile = analyzer.compile_commands_manager.get_compile_arg_profile(
+                Path(source_files[0])
+            )
+            print("   compile_arg_profile(sample):")
+            print(f"      file: {profile['file']}")
+            print(f"      args_source: {profile['args_source']}")
+            print(f"      cxx_standards: {profile['cxx_standards']}")
+            print(f"      system_include_dirs: {profile['system_include_dirs']}")
 
     # 4. Search for classes
     print("\n4. Searching for classes (pattern: '.*')...")

--- a/tests/test_compile_commands_manager.py
+++ b/tests/test_compile_commands_manager.py
@@ -474,6 +474,33 @@ class TestCompileCommandsManager(unittest.TestCase):
         self.assertEqual(stats["cache_enabled"], True)
         self.assertEqual(stats["fallback_enabled"], True)
         self.assertIn("compile_commands_path", stats)
+        self.assertIn("clang_resource_dir", stats)
+        self.assertIn("fallback_cxx_standards", stats)
+        self.assertIn("fallback_system_include_dirs", stats)
+
+    def test_get_compile_arg_profile_from_compile_commands(self):
+        """Compile arg profile should expose source, standards and system includes."""
+        config = {"compile_commands_enabled": True}
+        manager = CompileCommandsManager(self.project_root, config)
+
+        source_file = self.project_root / "src" / "main.cpp"
+        profile = manager.get_compile_arg_profile(source_file)
+
+        self.assertEqual(profile["args_source"], "compile_commands")
+        self.assertIn("c++17", profile["cxx_standards"])
+        self.assertIsInstance(profile["system_include_dirs"], list)
+        self.assertIn("clang_resource_dir", profile)
+
+    def test_get_compile_arg_profile_from_fallback(self):
+        """When file is not in compile DB, fallback profile should be reported."""
+        config = {"compile_commands_enabled": True, "fallback_to_hardcoded": True}
+        manager = CompileCommandsManager(self.project_root, config)
+
+        missing_file = self.project_root / "src" / "missing.cpp"
+        profile = manager.get_compile_arg_profile(missing_file)
+
+        self.assertEqual(profile["args_source"], "fallback")
+        self.assertIn("c++17", profile["cxx_standards"])
 
     def test_is_file_supported(self):
         """Test file support checking."""


### PR DESCRIPTION
## Summary
- move libclang discovery/configuration into a shared module and reuse it in both MCP server and console test script
- add startup/runtime diagnostics for libclang configuration
- add compile-argument diagnostics (C++ standard and system include directories) in analyzer/indexing logs
- expose compile argument profiling in compile commands manager and print a sample profile in console test script
- extend tests for compile command statistics/profile reporting

## Validation
- pre-commit checks: format + lint passed
- pre-push checks: full test suite passed (1429 passed, 16 skipped, 4 xpassed)
- note: mypy reported one informational/non-blocking issue in the shared libclang setup module