### PR TITLE
Simplify project setup to deterministic config-only model

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -52,36 +52,10 @@ All available configuration options:
 
 ## Configuration File Locations
 
-The analyzer looks for configuration files in the following locations (in priority order):
+The analyzer requires an **explicit** configuration file to be provided during project setup.
 
-### 1. Environment Variable (Highest Priority)
-Set the `CPP_ANALYZER_CONFIG` environment variable to point to a custom config file:
-
-```bash
-# Linux/macOS
-export CPP_ANALYZER_CONFIG="/path/to/my-custom-config.json"
-
-# Windows
-set CPP_ANALYZER_CONFIG=C:\path\to\my-custom-config.json
-```
-
-**Use case**: Temporary overrides, CI/CD pipelines, or testing different configurations.
-
-### 2. Project-Specific Configuration
-Place `.cpp-analyzer-config.json` (note the leading dot) in your C++ project root directory:
-
-```
-/path/to/your/cpp/project/
-├── .cpp-analyzer-config.json    ← Project-specific config (hidden on Unix)
-├── src/
-├── include/
-└── compile_commands.json
-```
-
-**Use case**: Per-project settings that persist with your codebase.
-
-### 3. Hybrid Project Entry Point (External Configuration)
-You can use a `.json` configuration file as the primary project "path" when calling `set_project`. This file does not need to be inside your source tree.
+### 1. Mandatory Project Configuration (Recommended)
+You must use a `.json` configuration file as the primary project "entry point" when calling `set_project`. This file does not need to be inside your source tree.
 
 To use this mode, the configuration file **must** include a `project_root` field:
 
@@ -98,6 +72,21 @@ To use this mode, the configuration file **must** include a `project_root` field
 If `project_root` is a relative path, it is resolved **relative to the directory containing the config file**.
 
 **Use case**: Multiple configurations for the same source, or keeping your source tree completely clean of MCP-specific files.
+
+### 2. Environment Variable Fallback
+If you are running the analyzer via scripts or CLI (outside of the MCP `set_project` tool), you can set the `CPP_ANALYZER_CONFIG` environment variable to point to a custom config file:
+
+```bash
+# Linux/macOS
+export CPP_ANALYZER_CONFIG="/path/to/my-custom-config.json"
+
+# Windows
+set CPP_ANALYZER_CONFIG=C:\path\to\my-custom-config.json
+```
+
+**Use case**: CI/CD pipelines or automated scripts.
+
+> **Note on Legacy Behavior**: Predefined configuration file discovery (e.g., searching for `.cpp-analyzer-config.json` in the project root) has been removed to ensure deterministic behavior. You must always provide an explicit path to a configuration file.
 
 ## Configuration File Format
 
@@ -324,7 +313,7 @@ python3 scripts/diagnose_cache.py
 
 ### Method 1: Manually Create
 
-Create `.cpp-analyzer-config.json` in your project root with your desired settings.
+Create a `.json` configuration file (e.g., `analysis-config.json`) with your desired settings.
 
 ### Method 2: Using Python API
 
@@ -332,23 +321,22 @@ Create `.cpp-analyzer-config.json` in your project root with your desired settin
 from mcp_server.cpp_analyzer_config import CppAnalyzerConfig
 from pathlib import Path
 
+# Initialize (project_root is required)
 config = CppAnalyzerConfig(Path("/path/to/your/project"))
 
-# Create in project root (recommended)
-config.create_example_config(location='project')
-
-# Or create at a custom path
-config.create_example_config(location='path')
+# Create example config at an explicit path
+config.create_example_config(Path("/path/to/analysis-config.json"))
 ```
 
 ## Configuration Priority Examples
 
 ### Example 1: Project-Specific Settings
 
-Create `/path/to/my/project/.cpp-analyzer-config.json`:
+Create `/path/to/my/project/config.json`:
 
 ```json
 {
+  "project_root": ".",
   "include_dependencies": false,
   "compile_commands": {
     "path": "build/compile_commands.json"
@@ -356,7 +344,7 @@ Create `/path/to/my/project/.cpp-analyzer-config.json`:
 }
 ```
 
-This configuration applies only to this specific project.
+This configuration applies to the project root where it's located.
 
 ### Example 2: Environment Variable Override
 
@@ -364,6 +352,7 @@ This configuration applies only to this specific project.
 # Create a custom config file
 cat > /tmp/special-config.json << 'EOF'
 {
+  "project_root": "/path/to/actual/project",
   "include_dependencies": true,
   "max_file_size_mb": 20,
   "compile_commands": {
@@ -378,16 +367,16 @@ export CPP_ANALYZER_CONFIG="/tmp/special-config.json"
 # Run your analysis - the analyzer will use /tmp/special-config.json
 ```
 
-This takes precedence over project-specific config.
+This takes precedence over any other configuration method.
 
 ### Example 3: Different Configs for Different Build Types
 
 ```bash
 # For debug builds
-export CPP_ANALYZER_CONFIG="$PWD/.cpp-analyzer-debug.json"
+export CPP_ANALYZER_CONFIG="$PWD/config-debug.json"
 
 # For release builds
-export CPP_ANALYZER_CONFIG="$PWD/.cpp-analyzer-release.json"
+export CPP_ANALYZER_CONFIG="$PWD/config-release.json"
 ```
 
 ## Recommendations
@@ -396,20 +385,20 @@ export CPP_ANALYZER_CONFIG="$PWD/.cpp-analyzer-release.json"
 
 When distributing as a Python package:
 
-1. **Include in .gitignore** (optional):
-   ```gitignore
-   # Optionally ignore the config if it's machine-specific
-   .cpp-analyzer-config.json
+1. **Keep configs separate** (optional):
+   ```
+   /configs/default.json
+   /configs/full-analysis.json
    ```
 
 2. **Include example config in repo**:
    ```
-   .cpp-analyzer-config.json.example
+   analysis-config.json.example
    ```
 
    Users can copy and customize:
    ```bash
-   cp .cpp-analyzer-config.json.example .cpp-analyzer-config.json
+   cp analysis-config.json.example analysis-config.json
    ```
 
 3. **Document in README**:
@@ -446,24 +435,22 @@ Use environment variable for build-specific settings:
 
 ### Config File Not Found
 
-If you see "No config file found, using defaults":
+If you see "Specified config file not found":
 
 ```
-No config file found, using defaults
-You can create a config file at:
-  - Project: /path/to/your/project/.cpp-analyzer-config.json
-  - Or set:  CPP_ANALYZER_CONFIG=<path>
+Specified config file not found: /path/to/missing-config.json
+Using default configuration
 ```
 
-**Solution**: Create `.cpp-analyzer-config.json` in your project root or set the environment variable.
+**Solution**: Ensure the path passed to `set_project` or `CPP_ANALYZER_CONFIG` is correct and absolute.
 
 ### Config File Not Loaded
 
 Check:
-1. File exists at the expected location
-2. Filename is exactly `.cpp-analyzer-config.json` (with leading dot)
-3. File contains valid JSON
-4. File has read permissions
+1. File exists at the specified location
+2. File contains valid JSON
+3. File has read permissions
+4. File contains a `project_root` field (if used as the primary entry point)
 5. Check stderr output for error messages
 
 ### Which Config is Being Used?
@@ -471,23 +458,10 @@ Check:
 The analyzer prints which config file is loaded:
 
 ```
-Loaded config from: /path/to/your/project/.cpp-analyzer-config.json
+Configuration loaded from specified file: /path/to/analysis-config.json
 ```
 
 If no message appears, defaults are being used.
-
-### Hidden File on Unix
-
-The leading dot makes the file hidden on Unix-like systems. To view it:
-
-```bash
-# List hidden files
-ls -la
-
-# Edit with your preferred editor
-nano .cpp-analyzer-config.json
-vim .cpp-analyzer-config.json
-```
 
 ## Examples
 
@@ -595,45 +569,44 @@ When you refresh the project, the analyzer:
 
 ### Project Identity
 
-Projects are uniquely identified by the combination of:
-- **Source directory path** (absolute)
-- **Configuration file path** (absolute, optional)
+Projects are uniquely identified by the **configuration file path** (absolute).
 
-Different combinations create separate cache directories:
+Different config file paths create separate cache directories:
 
 ```bash
-# Same source, no config → Same cache
-/project + (no config) → cache: project_abc123def456
-
 # Same source, different config → Different caches
-/project + /project/config1.json → cache: project_111aaa222bbb
-/project + /project/config2.json → cache: project_333ccc444ddd
+/configs/debug.json (points to /src) → cache: debug_abc123
+/configs/release.json (points to /src) → cache: release_def456
 
-# Different source, same config name → Different caches
-/project1 + /project1/config.json → cache: project1_555eee666fff
-/project2 + /project2/config.json → cache: project2_777ggg888hhh
+# Different source, same config name (but different paths) → Different caches
+/project1/config.json → cache: p1_111aaa
+/project2/config.json → cache: p2_222bbb
 ```
 
 This enables **multi-configuration workflows** where you can work with the same source code using different build configurations (Debug/Release, different compiler flags, etc.) without cache conflicts.
 
 ### MCP Tool Integration
 
-#### `set_project_directory` Tool
+#### `set_project` Tool
 
-When initializing a project, you can control incremental analysis behavior:
+This is the **mandatory first step** for any analysis. It initializes the project using a configuration file.
 
 ```json
 {
-  "project_path": "/path/to/project",
-  "config_file": "/path/to/project/.cpp-analyzer-config.json",
-  "auto_refresh": true
+  "config_file": "/path/to/my-project-config.json",
+  "sync_timeout": 30
 }
 ```
 
 **Parameters:**
-- `project_path` (required): Absolute path to project root
-- `config_file` (optional): Path to configuration file for project identity
-- `auto_refresh` (optional, default `true`): Automatically detect and re-analyze changes after loading cache
+- `config_file` (required): Absolute path to the `.json` configuration file. This file **must** contain a `project_root` field.
+- `sync_timeout` (optional, default `30`): Maximum seconds to wait for initial indexing to complete.
+
+**Behavior:**
+- The server reads the `config_file`, extracts and resolves the `project_root`.
+- Initializes the `CppAnalyzer` and starts background indexing.
+- Saves the session to `session.json` for auto-resume on restart.
+- Returns status `ready` if indexing completes within the timeout, or `indexing_in_progress` otherwise.
 
 **With `auto_refresh=true` (recommended):**
 - Loads cache if available

--- a/README.md
+++ b/README.md
@@ -155,16 +155,17 @@ Once configured, you can use the C++ analyzer in your conversations:
 
 ## Configuration Options
 
-The server behavior can be configured via a `.cpp-analyzer-config.json` file. The server looks for this file in:
-1. The path specified by the `CPP_ANALYZER_CONFIG` environment variable.
-2. The project root directory.
-3. A path explicitly passed to the `set_project` tool.
+The server behavior is configured via a `.json` configuration file. You must provide the path to this file when initializing the project.
+
+The server loads configuration from:
+1. The path explicitly passed to the `set_project` tool (recommended).
+2. The path specified by the `CPP_ANALYZER_CONFIG` environment variable.
 
 ### Example Configuration
 
 ```json
 {
-  "project_root": ".",
+  "project_root": "/path/to/source",
   "exclude_directories": [".git", "build", "node_modules"],
   "include_dependencies": true,
   "max_workers": null,

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -214,7 +214,7 @@ pip install libclang==14.0.0
 clang -print-resource-dir
 # Example: /Library/Developer/CommandLineTools/usr/lib/clang/14.0.0
 
-# Add to .cpp-analyzer-config.json
+# Add to your configuration file
 {
   "compile_commands": {
     "fallback_args": [

--- a/docs/MCP_TOOLS_CHEATSHEET.md
+++ b/docs/MCP_TOOLS_CHEATSHEET.md
@@ -32,7 +32,7 @@ Quick reference for C++ code analysis tools. All examples use YAML format for re
 ├─────────────────────────────────────────────────────────────────────────────┤
 │ PROJECT MANAGEMENT                                                          │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│ set_project_directory │ Set project root, start indexing                    │
+│ set_project        │ Set project via config file, start indexing            │
 │ refresh_project    │ Re-index changed files                                 │
 │ check_system_status │ Server health, indexing progress, statistics           │
 │ wait_for_indexing  │ Block until indexing complete                          │
@@ -372,23 +372,21 @@ path_length: 5
 
 ## Project Management Tools
 
-### set_project_directory
+### set_project
 
-Initialize project and start indexing.
+Initialize project using a configuration file.
 
 **Input:**
 ```yaml
-path: "/home/user/myproject"    # Required: project root
-config_file: "cpp-analyzer-config.json"  # Optional: custom config
+config_file: "/path/to/my-config.json"  # Required: path to config file
+sync_timeout: 30                        # Optional: seconds to wait
 ```
 
 **Output:**
 ```yaml
 status: indexing_started
-project_root: /home/user/myproject
-total_files: 1250
-config_used: /home/user/myproject/cpp-analyzer-config.json
-compile_commands: /home/user/myproject/build/compile_commands.json
+config_file: /path/to/my-config.json
+project_root: /path/to/resolved/root
 ```
 
 ### check_system_status

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -996,13 +996,14 @@ The system provides 14 MCP tools. Each tool has specific requirements for inputs
 
 ### 7.1 Configuration File
 
-**REQ-7.1.1**: The system SHALL support configuration file named `.cpp-analyzer-config.json`.
+**REQ-7.1.1**: The system SHALL support an explicit JSON configuration file provided during initialization.
 
-**REQ-7.1.2**: Configuration file locations SHALL be checked in order:
-1. Environment variable CPP_ANALYZER_CONFIG
-2. Project root directory
+**REQ-7.1.2**: Configuration file SHALL be provided via:
+1. `set_project` tool parameter `config_file`
+2. Environment variable `CPP_ANALYZER_CONFIG` (for CLI usage)
 
 **REQ-7.1.3**: Configuration SHALL support:
+- `project_root`: Absolute or relative path to the C++ project root
 - `exclude_directories`: List of directories to exclude (default: .git, .svn, node_modules, etc.)
 - `dependency_directories`: List of directories containing dependencies (default: vcpkg_installed, third_party, external, etc.)
 - `exclude_patterns`: List of file patterns to exclude (e.g., "*.generated.h")

--- a/mcp_server/consolidated_tools.py
+++ b/mcp_server/consolidated_tools.py
@@ -156,23 +156,19 @@ def list_tools_b() -> List[Tool]:
         Tool(
             name="set_project",
             description=(
-                "REQUIRED FIRST STEP: Set the C++ project to analyze. "
-                "The 'path' can be either a project root directory OR a .json configuration file "
-                "defining 'project_root'. Using a config file allows multiple analysis profiles "
-                "without polluting the source tree.\n\n"
+                "REQUIRED FIRST STEP: Set the C++ project to analyze using a configuration file. "
+                "The configuration file MUST be a .json file that defines 'project_root' "
+                "(absolute path or relative to the config file).\n\n"
+                "This allows multiple analysis profiles without polluting the source tree.\n\n"
                 "Indexes all C++ files and waits for completion (up to sync_timeout seconds). "
                 "Returns 'ready' when finished, or 'indexing_in_progress' if timeout exceeded."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Absolute path to C++ project root directory OR a .json config file.",
-                    },
                     "config_file": {
                         "type": "string",
-                        "description": "Optional: Path to cpp-analyzer-config.json (if 'path' is a directory).",
+                        "description": "Absolute path to the .json configuration file defining 'project_root'.",
                     },
                     "sync_timeout": {
                         "type": "number",
@@ -183,7 +179,7 @@ def list_tools_b() -> List[Tool]:
                         "default": 30,
                     },
                 },
-                "required": ["path"],
+                "required": ["config_file"],
             },
         ),
         Tool(
@@ -628,15 +624,13 @@ async def handle_tool_call_b(name: str, arguments: Dict[str, Any]) -> List[TextC
 
 
 async def _handle_set_project(arguments: Dict[str, Any]) -> List[TextContent]:
-    """Handle set_project: set directory + synchronous wait for indexing."""
+    """Handle set_project: set directory via config file + synchronous wait for indexing."""
     from mcp_server.cpp_mcp_server import _handle_tool_call
 
-    # Map 'path' -> 'project_path' for internal handler
+    config_file = arguments["config_file"]
     internal_args: Dict[str, Any] = {
-        "project_path": arguments["path"],
+        "config_file": config_file,
     }
-    if "config_file" in arguments:
-        internal_args["config_file"] = arguments["config_file"]
 
     # Step 1: Set project directory (starts background indexing)
     await _handle_tool_call("set_project_directory", internal_args)
@@ -658,7 +652,7 @@ async def _handle_set_project(arguments: Dict[str, Any]) -> List[TextContent]:
         system_state = "not_ready"
 
     response = {
-        "project_path": arguments["path"],
+        "config_file": config_file,
         "status": "ready" if system_state == "ready" else "indexing_in_progress",
     }
 

--- a/mcp_server/cpp_analyzer_config.py
+++ b/mcp_server/cpp_analyzer_config.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 # Handle both package and script imports
 try:
@@ -14,8 +14,6 @@ except ImportError:
 
 class CppAnalyzerConfig:
     """Loads and manages configuration for the C++ analyzer."""
-
-    CONFIG_FILENAME = ".cpp-analyzer-config.json"
 
     DEFAULT_CONFIG = {
         "exclude_directories": [
@@ -55,70 +53,26 @@ class CppAnalyzerConfig:
         self.config_path = config_path  # Pre-specified config path
         self.config = self._load_config()
 
-    def _find_config_file(self) -> Tuple[Optional[Path], Optional[str]]:
-        """Find config file by checking multiple locations in priority order.
-
-        Priority order:
-        1. Pre-specified config_path (from constructor)
-        2. Environment variable CPP_ANALYZER_CONFIG
-        3. Project root (.cpp-analyzer-config.json)
-
-        Returns tuple of (config_path, source_description) or (None, None) if not found.
-        """
-        # 1. Check pre-specified path
-        if self.config_path:
-            if self.config_path.exists():
-                diagnostics.debug(f"Using pre-specified config: {self.config_path}")
-                return (self.config_path, "specified config file")
-            else:
-                diagnostics.warning(f"Specified config file not found: {self.config_path}")
-
-        # 2. Check environment variable
-        env_config = os.environ.get("CPP_ANALYZER_CONFIG")
-        if env_config:
-            env_path = Path(env_config)
-            if env_path.exists():
-                diagnostics.debug(f"Using config from CPP_ANALYZER_CONFIG: {env_path}")
-                return (env_path, "environment variable CPP_ANALYZER_CONFIG")
-            else:
-                diagnostics.warning(f"CPP_ANALYZER_CONFIG points to non-existent file: {env_path}")
-
-        # 2. Check project root
-        project_config = self.project_root / self.CONFIG_FILENAME
-        if project_config.exists():
-            diagnostics.debug(f"Using config from project root: {project_config}")
-            return (project_config, "project root directory")
-
-        diagnostics.debug(
-            f"No config file found. Checked: {project_config}, env var: {'set' if env_config else 'not set'}"
-        )
-        return (None, None)
-
     def _load_config(self) -> Dict[str, Any]:
         """Load configuration from file or use defaults."""
-        config_file, config_source = self._find_config_file()
-
         config = self.DEFAULT_CONFIG.copy()
 
-        if config_file:
-            self.config_path = config_file
+        if self.config_path:
+            if not self.config_path.exists():
+                diagnostics.warning(f"Specified config file not found: {self.config_path}")
+                diagnostics.configure_from_config(config)
+                return config
+
             try:
-                with open(config_file, "r") as f:
+                with open(self.config_path, "r") as f:
                     user_config = json.load(f)
 
                 # Validate that the config file contains a JSON object, not an array
                 if not isinstance(user_config, dict):
-                    diagnostics.error(f"Invalid config file format at {config_file}")
+                    diagnostics.error(f"Invalid config file format at {self.config_path}")
                     diagnostics.error(
                         f"Expected a JSON object (dict), but got {type(user_config).__name__}"
                     )
-                    diagnostics.error(
-                        "Note: If you see 'compile_commands.json' here, you may have:"
-                    )
-                    diagnostics.error(
-                        "  1. Set CPP_ANALYZER_CONFIG environment variable to wrong file"
-                    )
-                    diagnostics.error("  2. Named .cpp-analyzer-config.json incorrectly")
                     diagnostics.warning("Using default configuration")
                     return config
 
@@ -128,19 +82,15 @@ class CppAnalyzerConfig:
                 # Configure diagnostics system from config
                 diagnostics.configure_from_config(config)
 
-                diagnostics.debug(f"Configuration loaded from {config_source}: {config_file}")
+                diagnostics.debug(f"Configuration loaded from specified file: {self.config_path}")
                 return config
             except Exception as e:
-                diagnostics.error(f"Error loading config from {config_file}: {e}")
+                diagnostics.error(f"Error loading config from {self.config_path}: {e}")
                 diagnostics.warning("Using default configuration")
         else:
             # Configure diagnostics with defaults
             diagnostics.configure_from_config(config)
-
-            diagnostics.debug("No config file found, using defaults")
-            diagnostics.debug(
-                f"You can create a config file at: {self.project_root / self.CONFIG_FILENAME}"
-            )
+            diagnostics.debug("No config file provided, using defaults")
 
         return config
 
@@ -247,19 +197,18 @@ class CppAnalyzerConfig:
             "exclude_patterns": compile_commands.get("exclude_patterns", []),
         }
 
-    def create_example_config(self, location: str = "project") -> Path:
-        """Create an example configuration file.
+    def create_example_config(self, target_path: Path) -> Path:
+        """Create an example configuration file at the specified path.
 
         Args:
-            location: Where to create the config file:
-                     'project' - Project root directory (default)
-                     'path' - Custom path (uses self.config_path if set)
+            target_path: Absolute path to the file to be created.
 
         Returns:
             Path to the created config file
         """
         example_config = {
             "_comment": "C++ Analyzer configuration file",
+            "project_root": ".",
             "exclude_directories": [
                 ".git",
                 ".svn",
@@ -292,18 +241,6 @@ class CppAnalyzerConfig:
             },
             "diagnostics": {"level": "info", "enabled": True},
         }
-
-        # Determine target path
-        if location == "project":
-            target_path = self.project_root / self.CONFIG_FILENAME
-        elif location == "path":
-            if self.config_path:
-                target_path = self.config_path
-            else:
-                # Default to project root
-                target_path = self.project_root / self.CONFIG_FILENAME
-        else:
-            raise ValueError(f"Invalid location: {location}. Use 'project' or 'path'.")
 
         # Write the config file
         with open(target_path, "w") as f:

--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -334,105 +334,65 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
 async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
     try:
         if name == "set_project_directory":
-            project_path = arguments["project_path"]
-            config_file = arguments.get("config_file", None)
+            config_file = arguments.get("config_file")
             auto_refresh = arguments.get("auto_refresh", True)
 
-            if not isinstance(project_path, str) or not project_path.strip():
+            if not config_file or not isinstance(config_file, str) or not config_file.strip():
+                return [
+                    TextContent(type="text", text="Error: 'config_file' must be a non-empty string")
+                ]
+
+            config_file = config_file.strip()
+
+            if not os.path.isabs(config_file):
+                return [
+                    TextContent(type="text", text=f"Error: '{config_file}' is not an absolute path")
+                ]
+
+            if not os.path.isfile(config_file):
                 return [
                     TextContent(
-                        type="text", text="Error: 'project_path' must be a non-empty string"
+                        type="text", text=f"Error: Config file '{config_file}' does not exist"
                     )
                 ]
 
-            if project_path != project_path.strip():
+            if not config_file.endswith(".json"):
                 return [
                     TextContent(
                         type="text",
-                        text="Error: 'project_path' may not include leading or trailing whitespace",
+                        text=f"Error: Config file '{config_file}' must have .json extension",
                     )
                 ]
 
-            project_path = project_path.strip()
+            try:
+                with open(config_file, "r") as f:
+                    config_data = json.load(f)
 
-            if not os.path.isabs(project_path):
-                return [
-                    TextContent(
-                        type="text", text=f"Error: '{project_path}' is not an absolute path"
-                    )
-                ]
-
-            # Hybrid approach: project_path can be a directory OR a config file
-            if os.path.isfile(project_path):
-                if not project_path.endswith(".json"):
+                config_root = config_data.get("project_root")
+                if not config_root:
                     return [
                         TextContent(
                             type="text",
-                            text=f"Error: Config file '{project_path}' must have .json extension",
+                            text=f"Error: Config file '{config_file}' is missing 'project_root' field",
                         )
                     ]
-                try:
-                    with open(project_path, "r") as f:
-                        config_data = json.load(f)
 
-                    config_root = config_data.get("project_root")
-                    if not config_root:
-                        return [
-                            TextContent(
-                                type="text",
-                                text=f"Error: Config file '{project_path}' is missing 'project_root' field",
-                            )
-                        ]
+                # Resolve project_root relative to config file directory
+                config_dir = os.path.dirname(config_file)
+                project_path = os.path.abspath(os.path.join(config_dir, config_root))
 
-                    # Resolve project_root relative to config file directory
-                    config_dir = os.path.dirname(project_path)
-                    resolved_root = os.path.abspath(os.path.join(config_dir, config_root))
-
-                    if not os.path.isdir(resolved_root):
-                        return [
-                            TextContent(
-                                type="text",
-                                text=f"Error: 'project_root' in config '{resolved_root}' is not a directory or does not exist",
-                            )
-                        ]
-
-                    # Swap: the file becomes the config_file, the extracted path becomes project_path
-                    config_file = project_path
-                    project_path = resolved_root
-                    diagnostics.info(
-                        f"Hybrid setup: Using config {config_file} for root {project_path}"
-                    )
-                except Exception as e:
-                    return [TextContent(type="text", text=f"Error reading config file: {str(e)}")]
-            elif not os.path.isdir(project_path):
-                return [
-                    TextContent(
-                        type="text",
-                        text=f"Error: Directory or config file '{project_path}' does not exist",
-                    )
-                ]
-
-            # Validate config_file if provided (and not already set by hybrid path)
-            if config_file and not os.path.isfile(config_file):
-                if not isinstance(config_file, str) or not config_file.strip():
+                if not os.path.isdir(project_path):
                     return [
                         TextContent(
-                            type="text", text="Error: 'config_file' must be a non-empty string"
+                            type="text",
+                            text=f"Error: 'project_root' in config '{project_path}' is not a directory or does not exist",
                         )
                     ]
-                config_file = config_file.strip()
-                if not os.path.isabs(config_file):
-                    return [
-                        TextContent(
-                            type="text", text=f"Error: '{config_file}' is not an absolute path"
-                        )
-                    ]
-                if not os.path.isfile(config_file):
-                    return [
-                        TextContent(
-                            type="text", text=f"Error: Config file '{config_file}' does not exist"
-                        )
-                    ]
+
+                diagnostics.info(f"Using config {config_file} for root {project_path}")
+
+            except Exception as e:
+                return [TextContent(type="text", text=f"Error reading config file: {str(e)}")]
 
             # Re-initialize analyzer with new path and config
             global analyzer, background_indexer, tool_call_logger
@@ -511,10 +471,9 @@ async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextCo
             asyncio.create_task(run_background_indexing())
 
             # Save session for auto-resume on restart
-            session_manager.save_session(project_path, config_file)
+            session_manager.save_session(config_file=config_file)
 
             # Build response message
-            config_msg = f" with config '{config_file}'" if config_file else ""
             auto_refresh_msg = (
                 " Auto-refresh enabled." if auto_refresh else " Auto-refresh disabled."
             )
@@ -523,7 +482,8 @@ async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextCo
             return [
                 TextContent(
                     type="text",
-                    text=f"Set project directory to: {project_path}{config_msg}\n"
+                    text=f"Set project via config: {config_file}\n"
+                    f"Resolved project root: {project_path}\n"
                     f"Indexing started in background.{auto_refresh_msg}\n"
                     f"Use 'sync_project' to check progress.\n"
                     f"Tools are available but will return partial results until indexing completes.",
@@ -1100,12 +1060,24 @@ async def main():
     disable_auto_resume = os.environ.get("MCP_DISABLE_SESSION_RESUME", "false").lower() == "true"
     saved_session = None if disable_auto_resume else session_manager.load_session()
     if saved_session:
-        project_path = saved_session["project_path"]
         config_file = saved_session.get("config_file")
 
-        diagnostics.info(f"Auto-resuming last session: {project_path}")
-
         try:
+            # Extract project_root from config file
+            with open(config_file, "r") as f:
+                config_data = json.load(f)
+
+            config_root = config_data.get("project_root")
+            if not config_root:
+                raise ValueError(f"Config file {config_file} missing 'project_root'")
+
+            # Resolve project_root relative to config file directory
+            config_dir = os.path.dirname(config_file)
+            project_path = os.path.abspath(os.path.join(config_dir, config_root))
+
+            diagnostics.info(f"Auto-resuming session via config: {config_file}")
+            diagnostics.info(f"Resolved project root: {project_path}")
+
             # Initialize analyzer with saved project
             state_manager.transition_to(AnalyzerState.INITIALIZING)
             analyzer = CppAnalyzer(project_path, config_file=config_file)

--- a/mcp_server/project_identity.py
+++ b/mcp_server/project_identity.py
@@ -109,7 +109,7 @@ class ProjectIdentity:
 
         Example:
             Source: /home/user/myproject
-            Config: /home/user/myproject/.cpp-analyzer-config.json
+            Config: /home/user/configs/my-config.json
             Result: "myproject_a1b2c3d4e5f6g7h8"
         """
         project_name = self.source_directory.name or "project"

--- a/mcp_server/session_manager.py
+++ b/mcp_server/session_manager.py
@@ -25,22 +25,20 @@ class SessionManager:
         self.cache_dir = Path(cache_dir)
         self.session_file = self.cache_dir / "session.json"
 
-    def save_session(self, project_path: str, config_file: Optional[str] = None) -> None:
+    def save_session(self, config_file: str) -> None:
         """Save current session to disk
 
         Args:
-            project_path: Absolute path to project directory
-            config_file: Optional path to config file
+            config_file: Absolute path to the configuration file
         """
         try:
             # Ensure cache directory exists
             self.cache_dir.mkdir(parents=True, exist_ok=True)
 
             session_data = {
-                "project_path": str(project_path),
-                "config_file": str(config_file) if config_file else None,
+                "config_file": str(config_file),
                 "last_accessed": datetime.now(timezone.utc).isoformat(),
-                "version": "1.0",
+                "version": "2.0",  # Bump version due to schema change
             }
 
             # Atomic write via temp file
@@ -51,7 +49,7 @@ class SessionManager:
             # Atomic rename
             temp_file.replace(self.session_file)
 
-            diagnostics.debug(f"Session saved: {project_path}")
+            diagnostics.debug(f"Session saved: {config_file}")
 
         except Exception as e:
             diagnostics.warning(f"Failed to save session: {e}")
@@ -61,7 +59,7 @@ class SessionManager:
 
         Returns:
             Session data dict if valid session exists, None otherwise
-            Dict contains: project_path, config_file, last_accessed
+            Dict contains: config_file, last_accessed
         """
         try:
             if not self.session_file.exists():
@@ -76,17 +74,17 @@ class SessionManager:
                 diagnostics.warning("Invalid session file format")
                 return None
 
-            if "project_path" not in session_data:
-                diagnostics.warning("Session missing project_path")
+            if "config_file" not in session_data:
+                diagnostics.warning("Session missing config_file")
                 return None
 
-            # Check if project directory still exists
-            project_path = Path(session_data["project_path"])
-            if not project_path.exists() or not project_path.is_dir():
-                diagnostics.info(f"Saved project directory no longer exists: {project_path}")
+            # Check if config file still exists
+            config_file = Path(session_data["config_file"])
+            if not config_file.exists() or not config_file.is_file():
+                diagnostics.info(f"Saved config file no longer exists: {config_file}")
                 return None
 
-            diagnostics.debug(f"Loaded session: {session_data['project_path']}")
+            diagnostics.debug(f"Loaded session: {session_data['config_file']}")
             return session_data
 
         except Exception as e:

--- a/scripts/archived/debug_args.py
+++ b/scripts/archived/debug_args.py
@@ -12,8 +12,9 @@ from mcp_server.compile_commands_manager import CompileCommandsManager
 from mcp_server.cpp_analyzer_config import CppAnalyzerConfig
 
 project_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+config_path = Path(sys.argv[2]) if len(sys.argv) > 2 else None
 
-config = CppAnalyzerConfig(project_root)
+config = CppAnalyzerConfig(project_root, config_path=config_path)
 cc_config = config.get_compile_commands_config()
 cc_manager = CompileCommandsManager(project_root, cc_config)
 

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -680,10 +680,10 @@ class TestSetProjectRouting:
             return _tc({"result": "ok"})
 
         with patch("mcp_server.cpp_mcp_server._handle_tool_call", side_effect=mock_handle):
-            result = await handle_tool_call_b("set_project", {"path": "/tmp/proj"})
+            result = await handle_tool_call_b("set_project", {"config_file": "/tmp/c.json"})
             parsed = _parse_tc(result)
             assert parsed["status"] == "ready"
-            assert parsed["project_path"] == "/tmp/proj"
+            assert parsed["config_file"] == "/tmp/c.json"
             # Should have called: set_project_directory, wait_for_indexing, check_system_status
             call_names = [c[0] for c in calls]
             assert "set_project_directory" in call_names
@@ -691,8 +691,8 @@ class TestSetProjectRouting:
             assert "check_system_status" in call_names
 
     @pytest.mark.asyncio
-    async def test_set_project_maps_path_param(self) -> None:
-        """set_project 'path' param maps to 'project_path' internally."""
+    async def test_set_project_passes_config_param(self) -> None:
+        """set_project 'config_file' param is forwarded to internal handler."""
         captured_args: dict[str, Any] = {}
 
         async def mock_handle(name: str, args: Any) -> list[TextContent]:
@@ -703,9 +703,8 @@ class TestSetProjectRouting:
             return _tc({"result": "ok"})
 
         with patch("mcp_server.cpp_mcp_server._handle_tool_call", side_effect=mock_handle):
-            await handle_tool_call_b("set_project", {"path": "/tmp/proj", "config_file": "/c.json"})
-            assert captured_args["project_path"] == "/tmp/proj"
-            assert captured_args["config_file"] == "/c.json"
+            await handle_tool_call_b("set_project", {"config_file": "/tmp/c.json"})
+            assert captured_args["config_file"] == "/tmp/c.json"
 
     @pytest.mark.asyncio
     async def test_set_project_indexing_in_progress(self) -> None:
@@ -717,7 +716,7 @@ class TestSetProjectRouting:
             return _tc({"result": "ok"})
 
         with patch("mcp_server.cpp_mcp_server._handle_tool_call", side_effect=mock_handle):
-            result = await handle_tool_call_b("set_project", {"path": "/tmp/proj"})
+            result = await handle_tool_call_b("set_project", {"config_file": "/tmp/c.json"})
             parsed = _parse_tc(result)
             assert parsed["status"] == "indexing_in_progress"
 

--- a/tests/test_hybrid_setup.py
+++ b/tests/test_hybrid_setup.py
@@ -13,33 +13,28 @@ from mcp_server.cpp_analyzer_config import CppAnalyzerConfig
 from mcp_server.cpp_mcp_server import _handle_tool_call
 
 @pytest.mark.asyncio
-async def test_cpp_analyzer_config_prioritization():
-    """Test that CppAnalyzerConfig prioritizes the explicitly passed path."""
+async def test_cpp_analyzer_config_explicit_only():
+    """Test that CppAnalyzerConfig only uses the explicitly passed path."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
         
-        # 1. Project root config (lower priority)
         project_root = tmp_path / "project"
         project_root.mkdir()
-        root_config = project_root / ".cpp-analyzer-config.json"
-        with open(root_config, "w") as f:
-            json.dump({"max_file_size_mb": 50}, f)
-            
-        # 2. External config (higher priority)
+        
+        # External config
         external_config = tmp_path / "external.json"
         with open(external_config, "w") as f:
             json.dump({"max_file_size_mb": 99}, f)
             
-        # Initialize config with both present
+        # Initialize config with explicit path
         config = CppAnalyzerConfig(project_root, config_path=external_config)
         
-        # Should pick external_config (99) over root_config (50)
         assert config.get_max_file_size_mb() == 99
         assert config.config_path == external_config
 
 @pytest.mark.asyncio
 async def test_hybrid_project_setup():
-    """Test setting project directory via a configuration file."""
+    """Test setting project via a configuration file."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
         
@@ -73,7 +68,7 @@ async def test_hybrid_project_setup():
             
             # Call set_project_directory with the config file path
             arguments = {
-                "project_path": str(config_file.absolute()),
+                "config_file": str(config_file.absolute()),
                 "auto_refresh": True
             }
             
@@ -81,13 +76,11 @@ async def test_hybrid_project_setup():
             results = await _handle_tool_call("set_project_directory", arguments)
             
             # Verify results
-            assert "Set project directory to" in results[0].text
+            assert "Set project via config" in results[0].text
             assert str(project_dir.absolute()) in results[0].text
             assert str(config_file.absolute()) in results[0].text
             
             # Verify MockAnalyzer was called with resolved paths
-            # The first argument should be the resolved project root
-            # The config_file argument should be the config file path
             args, kwargs = MockAnalyzer.call_args
             assert args[0] == str(project_dir.absolute())
             assert kwargs["config_file"] == str(config_file.absolute())
@@ -106,7 +99,7 @@ async def test_hybrid_project_setup_invalid_root():
             json.dump(config_data, f)
             
         arguments = {
-            "project_path": str(config_file.absolute())
+            "config_file": str(config_file.absolute())
         }
         
         results = await _handle_tool_call("set_project_directory", arguments)
@@ -127,7 +120,7 @@ async def test_hybrid_project_setup_missing_field():
             json.dump(config_data, f)
             
         arguments = {
-            "project_path": str(config_file.absolute())
+            "config_file": str(config_file.absolute())
         }
         
         results = await _handle_tool_call("set_project_directory", arguments)

--- a/tests/test_session_features.py
+++ b/tests/test_session_features.py
@@ -72,7 +72,7 @@ def test_config_validation(results):
             with open(valid_config, "w") as f:
                 json.dump({"max_file_size_mb": 20}, f)
 
-            config = CppAnalyzerConfig(valid_dir)
+            config = CppAnalyzerConfig(valid_dir, config_path=valid_config)
             assert config.get_max_file_size_mb() == 20, "Config value should be loaded"
             results.record_pass("Valid config (JSON object) loads correctly")
         except Exception as e:
@@ -86,7 +86,7 @@ def test_config_validation(results):
             with open(invalid_config, "w") as f:
                 json.dump([{"file": "test.cpp"}], f)
 
-            config = CppAnalyzerConfig(invalid_dir)
+            config = CppAnalyzerConfig(invalid_dir, config_path=invalid_config)
             # Should fall back to defaults without crashing
             assert config.get_max_file_size_mb() == 10, "Should use default on invalid config"
             results.record_pass("Invalid config (JSON array) falls back to defaults")
@@ -112,7 +112,7 @@ def test_config_validation(results):
             with open(retry_config, "w") as f:
                 json.dump({"max_parse_retries": 5}, f)
 
-            config = CppAnalyzerConfig(retry_dir)
+            config = CppAnalyzerConfig(retry_dir, config_path=retry_config)
             assert config.config.get("max_parse_retries") == 5, "Custom retry count should load"
             results.record_pass("Config with max_parse_retries loads correctly")
         except Exception as e:
@@ -414,7 +414,7 @@ def test_integration(results):
             with open(config_file, "w") as f:
                 json.dump({"max_parse_retries": 3}, f)
 
-            config = CppAnalyzerConfig(tmpdir_path)
+            config = CppAnalyzerConfig(tmpdir_path, config_path=config_file)
             assert config.config.get("max_parse_retries") == 3, "Custom retry loaded"
 
             # Create cache manager

--- a/tests/test_tools_during_analysis_policies.py
+++ b/tests/test_tools_during_analysis_policies.py
@@ -52,7 +52,7 @@ def test_config_file_query_behavior(temp_project_with_config):
     config_file.write_text(json.dumps(config_data))
 
     # Load config
-    config = CppAnalyzerConfig(temp_project_with_config)
+    config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
 
     policy = config.get_query_behavior_policy()
     assert policy == "block", "Should read policy from config file"
@@ -64,7 +64,7 @@ def test_config_file_reject_policy(temp_project_with_config):
     config_data = {"query_behavior": "reject"}
     config_file.write_text(json.dumps(config_data))
 
-    config = CppAnalyzerConfig(temp_project_with_config)
+    config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
     policy = config.get_query_behavior_policy()
     assert policy == "reject", "Should read reject policy from config file"
 
@@ -78,7 +78,7 @@ def test_env_var_overrides_config_file(temp_project_with_config):
 
     # Set environment variable to block
     with patch.dict(os.environ, {"CPP_ANALYZER_QUERY_BEHAVIOR": "block"}):
-        config = CppAnalyzerConfig(temp_project_with_config)
+        config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
         policy = config.get_query_behavior_policy()
         assert policy == "block", "Env var should override config file"
 
@@ -97,7 +97,7 @@ def test_invalid_config_value_defaults_to_allow_partial(temp_project_with_config
     config_data = {"query_behavior": "invalid_value"}
     config_file.write_text(json.dumps(config_data))
 
-    config = CppAnalyzerConfig(temp_project_with_config)
+    config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
     policy = config.get_query_behavior_policy()
     assert policy == "allow_partial", "Invalid value should default to allow_partial"
 
@@ -109,7 +109,7 @@ def test_invalid_env_var_falls_back_to_config(temp_project_with_config):
     config_file.write_text(json.dumps(config_data))
 
     with patch.dict(os.environ, {"CPP_ANALYZER_QUERY_BEHAVIOR": "invalid"}):
-        config = CppAnalyzerConfig(temp_project_with_config)
+        config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
         policy = config.get_query_behavior_policy()
         assert policy == "reject", "Invalid env var should fall back to config"
 
@@ -125,12 +125,12 @@ def test_priority_order_env_config_default(temp_project_with_config):
     config_data = {"query_behavior": "block"}
     config_file.write_text(json.dumps(config_data))
 
-    config = CppAnalyzerConfig(temp_project_with_config)
+    config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
     assert config.get_query_behavior_policy() == "block"
 
     # Test 3: Env overrides config
     with patch.dict(os.environ, {"CPP_ANALYZER_QUERY_BEHAVIOR": "reject"}):
-        config = CppAnalyzerConfig(temp_project_with_config)
+        config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
         assert config.get_query_behavior_policy() == "reject"
 
 
@@ -189,7 +189,8 @@ def test_example_config_includes_query_behavior(temp_project_with_config):
     config = CppAnalyzerConfig(temp_project_with_config)
 
     # Create example config
-    example_path = config.create_example_config(location="project")
+    target_path = temp_project_with_config / "example-config.json"
+    example_path = config.create_example_config(target_path)
 
     # Read it back
     with open(example_path) as f:
@@ -227,7 +228,7 @@ def test_config_with_all_three_policies(temp_project_with_config):
         config_data = {"query_behavior": policy_value}
         config_file.write_text(json.dumps(config_data))
 
-        config = CppAnalyzerConfig(temp_project_with_config)
+        config = CppAnalyzerConfig(temp_project_with_config, config_path=config_file)
         assert config.get_query_behavior_policy() == policy_value
 
 


### PR DESCRIPTION
This PR refactors the project initialization logic to require an explicit configuration file.

Key changes:
- Removed 'path' parameter from 'set_project' tool; 'config_file' is now mandatory.
- 'project_root' must be defined inside the configuration file.
- Removed legacy automatic discovery of '.cpp-analyzer-config.json' from project root.
- Updated 'SessionManager' to persist only the config file path.
- Updated server auto-resume to derive project root from the saved config.
- Refactored tests and documentation to align with the new model.