### PR TITLE
Fix/get type alias info duplication

### DIFF
--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -4627,7 +4627,9 @@ class CppAnalyzer:
                     alias_names = self.cache_manager.get_aliases_for_canonical(
                         row["canonical_type"]
                     )
-                    aliases = []
+
+                    # Deduplicate aliases using qualified_name as key
+                    unique_aliases = {}
                     for alias_name in alias_names:
                         alias_cursor = conn.execute(
                             """
@@ -4640,21 +4642,25 @@ class CppAnalyzer:
                         )
                         alias_row = alias_cursor.fetchone()
                         if alias_row:
-                            alias_dict = {
-                                "name": alias_row["alias_name"],
-                                "qualified_name": alias_row["qualified_name"],
-                                "file": alias_row["file"],
-                                "line": alias_row["line"],
-                            }
-                            if alias_row["is_template_alias"]:
-                                alias_dict["is_template_alias"] = True
-                                if alias_row["template_params"]:
-                                    import json
+                            qualified_name = alias_row["qualified_name"]
+                            if qualified_name not in unique_aliases:
+                                alias_dict = {
+                                    "name": alias_row["alias_name"],
+                                    "qualified_name": qualified_name,
+                                    "file": alias_row["file"],
+                                    "line": alias_row["line"],
+                                }
+                                if alias_row["is_template_alias"]:
+                                    alias_dict["is_template_alias"] = True
+                                    if alias_row["template_params"]:
+                                        import json
 
-                                    alias_dict["template_params"] = json.loads(
-                                        alias_row["template_params"]
-                                    )
-                            aliases.append(alias_dict)
+                                        alias_dict["template_params"] = json.loads(
+                                            alias_row["template_params"]
+                                        )
+                                unique_aliases[qualified_name] = alias_dict
+
+                    aliases = list(unique_aliases.values())
 
                     return {
                         "canonical_type": row["canonical_type"],
@@ -4736,10 +4742,13 @@ class CppAnalyzer:
                 self.cache_manager.backend._ensure_connected()
                 conn = self.cache_manager.backend.conn
                 assert conn is not None
+
+                # Deduplicate aliases using qualified_name as key
+                unique_aliases = {}
                 for alias_name in alias_names:
                     cursor = conn.execute(
                         """
-                        SELECT alias_name, canonical_type, file, line, namespace,
+                        SELECT alias_name, qualified_name, canonical_type, file, line, namespace,
                                is_template_alias, template_params
                         FROM type_aliases
                         WHERE alias_name = ? OR qualified_name = ?
@@ -4748,30 +4757,30 @@ class CppAnalyzer:
                     )
                     row = cursor.fetchone()
                     if row:
-                        # Build qualified name
-                        qualified_alias = (
-                            f"{row['namespace']}::{row['alias_name']}"
-                            if row["namespace"]
-                            else row["alias_name"]
-                        )
+                        qualified_alias = row["qualified_name"]
 
-                        # Build alias dictionary
-                        alias_dict = {
-                            "name": row["alias_name"],
-                            "qualified_name": qualified_alias,
-                            "file": row["file"],
-                            "line": row["line"],
-                        }
+                        if qualified_alias not in unique_aliases:
+                            # Build alias dictionary
+                            alias_dict = {
+                                "name": row["alias_name"],
+                                "qualified_name": qualified_alias,
+                                "file": row["file"],
+                                "line": row["line"],
+                            }
 
-                        # Add template information if present (Phase 2.0)
-                        if row["is_template_alias"]:
-                            alias_dict["is_template_alias"] = True
-                            if row["template_params"]:
-                                import json
+                            # Add template information if present (Phase 2.0)
+                            if row["is_template_alias"]:
+                                alias_dict["is_template_alias"] = True
+                                if row["template_params"]:
+                                    import json
 
-                                alias_dict["template_params"] = json.loads(row["template_params"])
+                                    alias_dict["template_params"] = json.loads(
+                                        row["template_params"]
+                                    )
 
-                        aliases.append(alias_dict)
+                            unique_aliases[qualified_alias] = alias_dict
+
+                aliases = list(unique_aliases.values())
             except Exception as e:
                 # Log error but continue
                 diagnostics.debug(f"Failed to get alias details: {e}")

--- a/tests/test_get_type_alias_info_deduplication.py
+++ b/tests/test_get_type_alias_info_deduplication.py
@@ -1,0 +1,104 @@
+
+"""
+Unit tests for alias deduplication in get_type_alias_info.
+Ensures that namespaced aliases and other scenarios don't result in duplicate entries.
+"""
+
+import os
+import sys
+from pathlib import Path
+import pytest
+
+# Add the mcp_server directory to the path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from mcp_server.cpp_analyzer import CppAnalyzer
+from tests.utils.test_helpers import temp_compile_commands
+
+class TestAliasDeduplication:
+    """Tests to verify that get_type_alias_info returns unique aliases."""
+
+    def test_namespaced_alias_deduplication(self, temp_project_dir):
+        """
+        Verify that aliases in namespaces (where short name != qualified name)
+        are not duplicated in the output.
+        """
+        (temp_project_dir / "src" / "test.cpp").write_text(
+            """
+            namespace CO {
+                class StringView { };
+                using StringViewAlias = StringView;
+            }
+            """
+        )
+
+        temp_compile_commands(
+            temp_project_dir,
+            [
+                {
+                    "file": "src/test.cpp",
+                    "directory": str(temp_project_dir),
+                    "arguments": ["-std=c++17"],
+                }
+            ],
+        )
+
+        analyzer = CppAnalyzer(str(temp_project_dir))
+        analyzer.index_project()
+
+        # Case 1: Query by canonical type
+        result_canonical = analyzer.get_type_alias_info("CO::StringView")
+        assert result_canonical["canonical_type"] == "CO::StringView"
+        
+        alias_names = [a["qualified_name"] for a in result_canonical["aliases"]]
+        assert len(result_canonical["aliases"]) == 1, f"Expected 1 alias, found: {alias_names}"
+        assert result_canonical["aliases"][0]["qualified_name"] == "CO::StringViewAlias"
+
+        # Case 2: Query by alias name
+        result_alias = analyzer.get_type_alias_info("CO::StringViewAlias")
+        assert result_alias["canonical_type"] == "CO::StringView"
+        assert result_alias["input_was_alias"] is True
+        
+        alias_names = [a["qualified_name"] for a in result_alias["aliases"]]
+        assert len(result_alias["aliases"]) == 1, f"Expected 1 alias, found: {alias_names}"
+        assert result_alias["aliases"][0]["qualified_name"] == "CO::StringViewAlias"
+
+    def test_multiple_aliases_deduplication(self, temp_project_dir):
+        """
+        Verify that when multiple distinct aliases exist, each is returned once.
+        """
+        (temp_project_dir / "src" / "test.cpp").write_text(
+            """
+            class Widget { };
+            using WidgetAlias = Widget;
+            typedef Widget WidgetType;
+            namespace ui {
+                using UIWidget = ::Widget;
+            }
+            """
+        )
+
+        temp_compile_commands(
+            temp_project_dir,
+            [
+                {
+                    "file": "src/test.cpp",
+                    "directory": str(temp_project_dir),
+                    "arguments": ["-std=c++17"],
+                }
+            ],
+        )
+
+        analyzer = CppAnalyzer(str(temp_project_dir))
+        analyzer.index_project()
+
+        result = analyzer.get_type_alias_info("Widget")
+        assert result["canonical_type"] == "Widget"
+        
+        alias_names = sorted([a["qualified_name"] for a in result["aliases"]])
+        expected_names = sorted(["WidgetAlias", "WidgetType", "ui::UIWidget"])
+        
+        assert alias_names == expected_names, f"Expected {expected_names}, found: {alias_names}"
+        assert len(result["aliases"]) == 3


### PR DESCRIPTION
This PR fixes a bug where the `get_type_alias_info` tool returned duplicate entries in its aliases list. 

The issue was caused by `get_aliases_for_canonical` returning both short and qualified names, which led to querying the same database row multiple times. Includes regression tests.