### PR TITLE
Fix mypy type-check errors

### DIFF
--- a/mcp_server/cpp_analyzer.py
+++ b/mcp_server/cpp_analyzer.py
@@ -17,10 +17,10 @@ import sys
 import threading
 import time
 from collections import defaultdict, deque
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from .cache_manager import CacheManager
 from .call_graph import CallGraphAnalyzer
@@ -3545,6 +3545,7 @@ class CppAnalyzer:
 
         # Choose executor based on configuration
         # ProcessPoolExecutor bypasses Python's GIL for true parallelism
+        executor_class: Union[type[ProcessPoolExecutor], type[ThreadPoolExecutor]]
         if self.use_processes:
             # Use 'spawn' context to avoid inheriting open file descriptors (like SSE sockets)
             # This is critical for MCP servers where subprocesses might keep sockets open
@@ -3564,7 +3565,7 @@ class CppAnalyzer:
             mp_context = None
             diagnostics.debug(f"Using ThreadPoolExecutor with {self.max_workers} workers")
 
-        executor = None
+        executor: Optional[Executor] = None
         try:
             if self.use_processes and mp_context:
                 executor = ProcessPoolExecutor(max_workers=self.max_workers, mp_context=mp_context)
@@ -3572,6 +3573,7 @@ class CppAnalyzer:
                 executor = executor_class(max_workers=self.max_workers)
 
             if self.use_processes:
+                assert executor is not None
                 # ProcessPoolExecutor: use worker function that returns symbols
                 # Pass config_file to ensure workers use the same cache directory
                 config_file_str = (
@@ -3627,6 +3629,7 @@ class CppAnalyzer:
                 }
             else:
                 # ThreadPoolExecutor: use index_file method directly
+                assert executor is not None
                 future_to_file = {
                     executor.submit(
                         self.index_file, os.path.abspath(file_path), force

--- a/mcp_server/incremental_analyzer.py
+++ b/mcp_server/incremental_analyzer.py
@@ -23,7 +23,7 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Callable, Optional, Set
+from typing import Callable, Optional, Set, Union
 
 # Handle both package and script imports
 try:
@@ -357,7 +357,12 @@ class IncrementalAnalyzer:
 
         # Use analyzer's parallel processing infrastructure (same pattern as index_project)
         # ProcessPoolExecutor provides true parallelism (GIL bypass) for 6-7x speedup
-        from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+        from concurrent.futures import (
+            Executor,
+            ProcessPoolExecutor,
+            ThreadPoolExecutor,
+            as_completed,
+        )
         from unittest.mock import Mock
 
         use_processes = getattr(self.analyzer, "use_processes", True)
@@ -374,6 +379,7 @@ class IncrementalAnalyzer:
             max_workers = os.cpu_count() or 4
 
         # Choose executor based on configuration
+        executor_class: Union[type[ProcessPoolExecutor], type[ThreadPoolExecutor]]
         if use_processes:
             # Use 'spawn' context to avoid inheriting open file descriptors
             try:
@@ -393,7 +399,7 @@ class IncrementalAnalyzer:
                 f"Incremental refresh: Using ThreadPoolExecutor with {max_workers} workers"
             )
 
-        executor = None
+        executor: Optional[Executor] = None
         try:
             if use_processes and mp_context:
                 executor = ProcessPoolExecutor(max_workers=max_workers, mp_context=mp_context)
@@ -401,6 +407,7 @@ class IncrementalAnalyzer:
                 executor = executor_class(max_workers=max_workers)
 
             if use_processes:
+                assert executor is not None
                 # ProcessPoolExecutor: use worker function (same as index_project)
                 from pathlib import Path
 
@@ -465,6 +472,7 @@ class IncrementalAnalyzer:
                 }
             else:
                 # ThreadPoolExecutor: use index_file method directly
+                assert executor is not None
                 future_to_file = {
                     executor.submit(self.analyzer.index_file, file_path, force=True): file_path
                     for file_path in file_list

--- a/mcp_server/libclang_setup.py
+++ b/mcp_server/libclang_setup.py
@@ -114,7 +114,7 @@ def configure_libclang() -> bool:
     if llvm_config:
         try:
             result = subprocess.run(
-                [llvm_config, config["llvm_config_query"]],
+                [llvm_config, str(config["llvm_config_query"])],
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/mcp_server/state_manager.py
+++ b/mcp_server/state_manager.py
@@ -84,7 +84,7 @@ class AnalyzerStateManager:
 
     def wait_for_tools_to_finish(self, timeout: Optional[float] = None) -> bool:
         """Wait until there are no active tool calls."""
-        return self._tools_event.wait(timeout)
+        return bool(self._tools_event.wait(timeout))
 
     def tool_started(self):
         """Mark a tool call as started."""


### PR DESCRIPTION
This PR fixes 4 mypy type-check errors reported by `make type-check`:

- **mcp_server/libclang_setup.py**: Cast config value to `str` for `subprocess.run` list argument
- **mcp_server/state_manager.py**: Wrap `Event.wait()` return with `bool()`
- **mcp_server/cpp_analyzer.py**: Annotate `executor_class` and `executor` types, add `assert executor is not None` before submit calls
- **mcp_server/incremental_analyzer.py**: Annotate `executor_class` and `executor` types, add `assert executor is not None` before submit calls

All changes are type-safety improvements with no functional changes. Tests pass (1452 tests).