### PR TITLE
fix: resolve race condition in incremental sync state reporting

### DIFF
--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -693,12 +693,12 @@ async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextCo
                     "and sufficient for 99% of cases."
                 )
 
+            # Transition to REFRESHING state synchronously
+            state_manager.transition_to(AnalyzerState.REFRESHING)
+
             # Start refresh in background (non-blocking, similar to set_project_directory)
             async def run_background_refresh():
                 try:
-                    # Transition to REFRESHING state
-                    state_manager.transition_to(AnalyzerState.REFRESHING)
-
                     loop = asyncio.get_event_loop()
 
                     # Create progress callback that updates state_manager (same as BackgroundIndexer)

--- a/mcp_server/state_manager.py
+++ b/mcp_server/state_manager.py
@@ -125,7 +125,7 @@ class AnalyzerStateManager:
             # Set/clear indexed event based on state
             if new_state == AnalyzerState.INDEXED:
                 self._indexed_event.set()
-            elif new_state == AnalyzerState.INDEXING:
+            elif new_state in (AnalyzerState.INDEXING, AnalyzerState.REFRESHING):
                 self._indexed_event.clear()
 
             # Debug logging (will be picked up by diagnostics module)


### PR DESCRIPTION
## Description

When `sync_project` triggers an incremental analysis via `refresh_project`, it creates a background task that transitions the system state to `REFRESHING`. Previously, this state transition happened asynchronously inside the background task, causing immediate follow-up status checks (like `wait_for_indexing`) to read the outdated `INDEXED` state and instantly return without waiting.

This PR fixes the race condition by:
 1. Transitioning to `REFRESHING` synchronously before creating the background task.
 2. Properly clearing the `_indexed_event` flag in `StateManager` for the `REFRESHING` state, ensuring wait mechanisms block appropriately while the refresh is ongoing.
