### PR TITLE
fix: allow sync_project to auto-resume and work from uninitialized state

### DIFF
--- a/mcp_server/cpp_mcp_server.py
+++ b/mcp_server/cpp_mcp_server.py
@@ -656,7 +656,101 @@ async def _handle_find_in_file(arguments: Dict[str, Any]) -> List[TextContent]:
     return [TextContent(type="text", text=json.dumps(output, indent=2))]
 
 
+async def _ensure_analyzer_resumed() -> bool:
+    """Ensure analyzer is initialized, attempting auto-resume if needed."""
+    global analyzer, background_indexer, analyzer_initialized
+    if analyzer is not None:
+        return True
+
+    diagnostics.info("Attempting auto-resume of last used session...")
+    disable_auto_resume = os.environ.get("MCP_DISABLE_SESSION_RESUME", "false").lower() == "true"
+    saved_session = None if disable_auto_resume else session_manager.load_session()
+    if saved_session:
+        analyzer, background_indexer, analyzer_initialized = _try_resume_session(saved_session)
+
+    return analyzer is not None
+
+
+async def _run_background_refresh(refresh_mode: str):
+    """Background task to perform project refresh (incremental or full)."""
+    assert analyzer is not None
+    try:
+        loop = asyncio.get_event_loop()
+
+        # Create progress callback that updates state_manager (same as BackgroundIndexer)
+        def progress_callback(progress: IndexingProgress):
+            """Callback to update progress in state manager during refresh"""
+            state_manager.update_progress(progress)
+
+        def wait_for_tools():
+            """Wrapper to match Callable[[], None] expected by analyzers"""
+            state_manager.wait_for_tools_to_finish()
+
+        if refresh_mode == "incremental":
+            try:
+                from mcp_server.incremental_analyzer import IncrementalAnalyzer
+
+                diagnostics.info("Starting incremental refresh...")
+                incremental_analyzer = IncrementalAnalyzer(analyzer)
+                result = await loop.run_in_executor(
+                    None,
+                    lambda: incremental_analyzer.perform_incremental_analysis(
+                        progress_callback, wait_for_tools
+                    ),
+                )
+
+                if result and result.changes and result.changes.is_empty():
+                    diagnostics.info("Incremental refresh complete: no changes detected")
+                elif result:
+                    diagnostics.info(
+                        f"Incremental refresh complete: re-analyzed {result.files_analyzed} files, "
+                        f"removed {result.files_removed} files in {result.elapsed_seconds:.2f}s"
+                    )
+
+                state_manager.transition_to(AnalyzerState.INDEXED)
+                return
+
+            except Exception as e:
+                diagnostics.error(f"Incremental analysis failed: {e}")
+                diagnostics.info("Falling back to full refresh...")
+                # Fallback to full refresh
+                modified_count = await loop.run_in_executor(
+                    None,
+                    lambda: analyzer.refresh_if_needed(progress_callback, wait_for_tools),
+                )
+                diagnostics.info(
+                    f"Fallback full refresh complete: re-analyzed {modified_count} files"
+                )
+                state_manager.transition_to(AnalyzerState.INDEXED)
+                return
+
+        else:
+            # Full refresh
+            diagnostics.info("Starting full refresh...")
+            modified_count = await loop.run_in_executor(
+                None, lambda: analyzer.refresh_if_needed(progress_callback)
+            )
+            diagnostics.info(f"Full refresh complete: re-analyzed {modified_count} files")
+            state_manager.transition_to(AnalyzerState.INDEXED)
+            return
+
+    except Exception as e:
+        diagnostics.error(f"Background refresh failed: {e}")
+        state_manager.transition_to(AnalyzerState.ERROR)
+        pass
+
+
 async def _handle_refresh_project(arguments: Dict[str, Any]) -> List[TextContent]:
+    """Handle refresh_project: trigger incremental or full re-indexing."""
+    # 1. If analyzer is None, try to resume session from last used config
+    if not await _ensure_analyzer_resumed():
+        return [
+            TextContent(
+                type="text",
+                text="Error: Project directory not set. Please use 'set_project_directory' first with the path to your C++ project.",
+            )
+        ]
+
     refresh_mode = arguments.get("refresh_mode", "incremental")
 
     # Issue #7: Warn if full mode is used (should be rare)
@@ -670,73 +764,8 @@ async def _handle_refresh_project(arguments: Dict[str, Any]) -> List[TextContent
     # Transition to REFRESHING state synchronously
     state_manager.transition_to(AnalyzerState.REFRESHING)
 
-    # Start refresh in background (non-blocking, similar to set_project_directory)
-    async def run_background_refresh():
-        try:
-            loop = asyncio.get_event_loop()
-
-            # Create progress callback that updates state_manager (same as BackgroundIndexer)
-            def progress_callback(progress: IndexingProgress):
-                """Callback to update progress in state manager during refresh"""
-                state_manager.update_progress(progress)
-
-            if refresh_mode == "incremental":
-                try:
-                    from mcp_server.incremental_analyzer import IncrementalAnalyzer
-
-                    diagnostics.info("Starting incremental refresh...")
-                    incremental_analyzer = IncrementalAnalyzer(analyzer)
-                    result = await loop.run_in_executor(
-                        None,
-                        lambda: incremental_analyzer.perform_incremental_analysis(
-                            progress_callback, state_manager.wait_for_tools_to_finish
-                        ),
-                    )
-
-                    if result.changes.is_empty():
-                        diagnostics.info("Incremental refresh complete: no changes detected")
-                    else:
-                        diagnostics.info(
-                            f"Incremental refresh complete: re-analyzed {result.files_analyzed} files, "
-                            f"removed {result.files_removed} files in {result.elapsed_seconds:.2f}s"
-                        )
-
-                    state_manager.transition_to(AnalyzerState.INDEXED)
-                    return
-
-                except Exception as e:
-                    diagnostics.error(f"Incremental analysis failed: {e}")
-                    diagnostics.info("Falling back to full refresh...")
-                    # Fallback to full refresh
-                    modified_count = await loop.run_in_executor(
-                        None,
-                        lambda: analyzer.refresh_if_needed(
-                            progress_callback, state_manager.wait_for_tools_to_finish
-                        ),
-                    )
-                    diagnostics.info(
-                        f"Fallback full refresh complete: re-analyzed {modified_count} files"
-                    )
-                    state_manager.transition_to(AnalyzerState.INDEXED)
-                    return
-
-            else:
-                # Full refresh
-                diagnostics.info("Starting full refresh...")
-                modified_count = await loop.run_in_executor(
-                    None, lambda: analyzer.refresh_if_needed(progress_callback)
-                )
-                diagnostics.info(f"Full refresh complete: re-analyzed {modified_count} files")
-                state_manager.transition_to(AnalyzerState.INDEXED)
-                return
-
-        except Exception as e:
-            diagnostics.error(f"Background refresh failed: {e}")
-            state_manager.transition_to(AnalyzerState.ERROR)
-            pass
-
     # Create background task (non-blocking)
-    asyncio.create_task(run_background_refresh())
+    asyncio.create_task(_run_background_refresh(refresh_mode))
 
     # Return immediately - refresh continues in background
     return [
@@ -750,9 +779,12 @@ async def _handle_refresh_project(arguments: Dict[str, Any]) -> List[TextContent
 
 
 async def _handle_check_system_status(arguments: Dict[str, Any]) -> List[TextContent]:
-    assert analyzer is not None
     # Combined server diagnostics and indexing status
     status_dict = state_manager.get_status_dict()
+    status_dict["analyzer_type"] = "python_enhanced"
+
+    if analyzer is None:
+        return [TextContent(type="text", text=json.dumps(status_dict, indent=2))]
 
     ccm = analyzer.compile_commands_manager
     total_classes = sum(len(infos) for infos in analyzer.class_index.values())
@@ -760,7 +792,6 @@ async def _handle_check_system_status(arguments: Dict[str, Any]) -> List[TextCon
 
     status_dict.update(
         {
-            "analyzer_type": "python_enhanced",
             "call_graph_enabled": True,
             "compile_commands_enabled": ccm.enabled if ccm else False,
             "compile_commands_path": ccm.compile_commands_path if ccm else None,
@@ -1031,41 +1062,74 @@ async def _handle_get_call_path(arguments: Dict[str, Any]) -> List[TextContent]:
     return [TextContent(type="text", text=json.dumps(output_paths, indent=2))]
 
 
-async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
-    try:
-        # 1. Management tools (no analyzer needed)
-        if name == "set_project_directory":
-            return await _handle_set_project_directory(arguments)
+def _check_tool_readiness(name: str) -> Optional[List[TextContent]]:
+    """
+    Check if a tool is ready to be executed based on current analyzer state.
+    Returns None if ready, or a List[TextContent] with an error message if not.
+    """
+    # Policy check and readiness for query tools
+    query_tools = {
+        "search_classes",
+        "search_functions",
+        "get_class_info",
+        "get_type_alias_info",
+        "search_symbols",
+        "find_in_file",
+        "get_class_hierarchy",
+        "find_incoming_calls",
+        "get_outgoing_calls",
+        "get_call_path",
+        "get_call_sites",
+    }
 
-        # 2. Check if analyzer is initialized
-        if analyzer is None or not state_manager.is_ready_for_queries():
+    if name in query_tools:
+        if analyzer is None:
             return [
                 TextContent(
                     type="text",
                     text="Error: Project directory not set. Please use 'set_project_directory' first with the path to your C++ project.",
                 )
             ]
+        if not state_manager.is_ready_for_queries():
+            return [
+                TextContent(
+                    type="text",
+                    text="Error: Project is not ready for queries yet. Use 'sync_project' to start indexing or check status.",
+                )
+            ]
 
-        # 3. Policy check for query tools
-        query_tools = {
-            "search_classes",
-            "search_functions",
-            "get_class_info",
-            "get_type_alias_info",
-            "search_symbols",
-            "find_in_file",
-            "get_class_hierarchy",
-            "find_incoming_calls",
-            "get_outgoing_calls",
-            "get_call_path",
-        }
+        allowed, policy_message = check_query_policy(name)
+        if not allowed:
+            return [TextContent(type="text", text=policy_message)]
 
-        if name in query_tools:
-            allowed, policy_message = check_query_policy(name)
-            if not allowed:
-                return [TextContent(type="text", text=policy_message)]
+    # Check for other tools (refresh_project, wait_for_indexing)
+    if name in ("refresh_project", "wait_for_indexing") and analyzer is None:
+        # For refresh_project, we'll try to resume inside the handler
+        if name == "wait_for_indexing":
+            return [
+                TextContent(
+                    type="text",
+                    text="Error: Project directory not set. Please use 'set_project_directory' first.",
+                )
+            ]
 
-        # 4. Route to specific handler
+    return None
+
+
+async def _handle_tool_call(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+    try:
+        # 1. Management tools (handle their own state checks)
+        if name == "set_project_directory":
+            return await _handle_set_project_directory(arguments)
+        if name == "check_system_status":
+            return await _handle_check_system_status(arguments)
+
+        # 2. Check tool readiness
+        error_response = _check_tool_readiness(name)
+        if error_response:
+            return error_response
+
+        # 3. Route to specific handler
         handlers = {
             "search_classes": _handle_search_classes,
             "search_functions": _handle_search_functions,

--- a/tests/test_sync_project_auto_resume.py
+++ b/tests/test_sync_project_auto_resume.py
@@ -1,0 +1,103 @@
+
+import asyncio
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from mcp_server import cpp_mcp_server
+from mcp_server.state_manager import AnalyzerState
+
+@pytest.mark.asyncio
+async def test_sync_project_after_failed_resume():
+    # 1. Setup mock session and analyzer
+    mock_session = {"config_file": "/tmp/mock_config.json"}
+    
+    with patch("mcp_server.session_manager.SessionManager.load_session", return_value=mock_session), \
+         patch("mcp_server.cpp_mcp_server._try_resume_session") as mock_resume, \
+         patch("mcp_server.cpp_mcp_server.state_manager") as mock_state_manager:
+        
+        # Mock resume failure (returns analyzer but state is UNINITIALIZED)
+        mock_analyzer = MagicMock()
+        mock_background_indexer = MagicMock()
+        mock_resume.return_value = (mock_analyzer, mock_background_indexer, False)
+        
+        # We need to actually set the global variables in cpp_mcp_server
+        cpp_mcp_server.analyzer = mock_analyzer
+        cpp_mcp_server.background_indexer = mock_background_indexer
+        
+        # Mock state_manager.is_ready_for_queries to return False (as it would for UNINITIALIZED)
+        mock_state_manager.is_ready_for_queries.return_value = False
+        
+        # 2. Call sync_project with refresh_mode="full"
+        from mcp_server.consolidated_tools import handle_tool_call_b
+        
+        arguments = {"refresh_mode": "full"}
+        result = await handle_tool_call_b("sync_project", arguments)
+        
+        print(f"Result: {result}")
+        
+        # Check if error message is ABSENT
+        assert not any("Error: Project directory not set" in content.text for content in result)
+        
+        # Verify if transition_to(AnalyzerState.REFRESHING) was called
+        refreshing_calls = [call for call in mock_state_manager.transition_to.call_args_list 
+                           if call.args[0] == AnalyzerState.REFRESHING]
+        
+        if refreshing_calls:
+            print("SUCCESS: Refresh WAS started despite initial UNINITIALIZED state.")
+        else:
+            print("FAILURE: Refresh was NOT started.")
+            assert refreshing_calls
+
+@pytest.mark.asyncio
+async def test_sync_project_auto_resumes_when_none():
+    # 1. Setup mock session (analyzer starts as None)
+    mock_session = {"config_file": "/tmp/mock_config.json"}
+    
+    with patch("mcp_server.session_manager.SessionManager.load_session", return_value=mock_session), \
+         patch("mcp_server.cpp_mcp_server._try_resume_session") as mock_resume, \
+         patch("mcp_server.cpp_mcp_server.state_manager") as mock_state_manager:
+        
+        # Mock resume success
+        mock_analyzer = MagicMock()
+        mock_background_indexer = MagicMock()
+        mock_resume.return_value = (mock_analyzer, mock_background_indexer, True)
+        
+        # Ensure analyzer starts as None
+        cpp_mcp_server.analyzer = None
+        
+        # 2. Call sync_project with refresh_mode="full"
+        from mcp_server.consolidated_tools import handle_tool_call_b
+        
+        arguments = {"refresh_mode": "full"}
+        result = await handle_tool_call_b("sync_project", arguments)
+        
+        # Check if _try_resume_session was called
+        mock_resume.assert_called_once()
+        
+        # Check if error message is ABSENT
+        assert not any("Error: Project directory not set" in content.text for content in result)
+        
+        print("SUCCESS: sync_project auto-resumed session.")
+
+@pytest.mark.asyncio
+async def test_sync_project_status_works_when_none():
+    # Reset state_manager and ensure analyzer is None
+    from mcp_server.cpp_mcp_server import state_manager
+    state_manager.transition_to(AnalyzerState.UNINITIALIZED)
+    cpp_mcp_server.analyzer = None
+    
+    from mcp_server.consolidated_tools import handle_tool_call_b
+    
+    # sync_project with no args returns status
+    result = await handle_tool_call_b("sync_project", {})
+    
+    # Check if result contains JSON with uninitialized state
+    data = json.loads(result[0].text)
+    assert data["state"] == "uninitialized"
+    assert "analyzer_type" in data
+    
+    print("SUCCESS: sync_project status works when analyzer is None.")
+
+if __name__ == "__main__":
+    asyncio.run(test_sync_project_after_failed_resume())


### PR DESCRIPTION
## Description

This change allows management tools like `sync_project` (`refresh_project`, `check_system_status`, `wait_for_indexing`) to work even if the project is not yet fully indexed or if it was resumed from a previous session but the cache is invalid. It also adds auto-resume support to refresh_project if no analyzer is currently initialized but a saved session exists.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements

### Test Results

- [X] All existing tests pass
- [X] New tests added and pass
- [X] Manually tested with sample C++ project
- [ ] Tested on multiple platforms (if applicable)
