### PR TITLE
Add package-level entry point via __main__.py and fix HTTP/SSE shutdown traceback

### DIFF
--- a/.ai/CLAUDE.md
+++ b/.ai/CLAUDE.md
@@ -68,9 +68,9 @@ make run                        # Run MCP server (stdio transport)
 make dev                        # Run with MCP_DEBUG=1 and PYTHONUNBUFFERED=1
 
 # Alternative transport protocols
-python -m mcp_server.cpp_mcp_server                                        # stdio (default)
-python -m mcp_server.cpp_mcp_server --transport http --port 8000           # HTTP
-python -m mcp_server.cpp_mcp_server --transport sse --port 8000            # SSE
+python -m mcp_server                                        # stdio (default)
+python -m mcp_server --transport http --port 8000           # HTTP
+python -m mcp_server --transport sse --port 8000            # SSE
 ```
 
 ### Testing and Debugging
@@ -103,7 +103,7 @@ Use the `/test-mcp` skill for automated MCP server testing:
 For low-level debugging or when automated testing isn't suitable, use SSE transport with curl:
 ```bash
 # Start SSE server
-MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server.cpp_mcp_server --transport sse --port 8000
+MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server --transport sse --port 8000
 
 # Call MCP tool
 curl -s -X POST http://localhost:8000/mcp/v1/tools/call \
@@ -121,7 +121,7 @@ make install-wheel              # Build and install wheel locally
 make install-editable           # Install in editable mode (recommended for dev)
 
 # After install-editable or install-wheel, you can run:
-clang-index-mcp                 # Entry point script (equivalent to python -m mcp_server.cpp_mcp_server)
+clang-index-mcp                 # Entry point script (equivalent to python -m mcp_server)
 ```
 
 ### Maintenance
@@ -322,7 +322,7 @@ Monitor file descriptors and resource usage during indexing to detect leaks:
 
 ```bash
 # Get the MCP server PID
-MCP_PID=$(pgrep -f "cpp_mcp_server" | head -1)
+MCP_PID=$(pgrep -f "python -m mcp_server" | head -1)
 
 # Monitor file descriptor counts (should stay stable at ~10-15)
 watch -n 2 'echo "=== FD Monitor ==="; \
@@ -397,7 +397,7 @@ The `diagnose_parse_errors.py` script tests parsing with different libclang opti
    - Update `CURRENT_SCHEMA_VERSION` in `sqlite_cache_backend.py`
    - Database will automatically recreate on version mismatch (development mode)
 4. Run `make test` to verify no regressions
-5. Test with example project: `python -m mcp_server.cpp_mcp_server` + set examples/compile_commands_example/
+5. Test with example project: `python -m mcp_server` + set examples/compile_commands_example/
 
 ### Cache Invalidation and Corruption Recovery
 

--- a/CLIENT_SETUP.md
+++ b/CLIENT_SETUP.md
@@ -19,7 +19,7 @@ This guide provides detailed instructions for configuring the C++ Analyzer MCP S
 Before configuring any client, ensure you have:
 
 1. Completed the [Setup](README.md#setup) steps
-2. The MCP server is working (test with `python -m mcp_server.cpp_mcp_server`)
+2. The MCP server is working (test with `python -m mcp_server`)
 3. Note the absolute path to your clang_index_mcp installation directory
 
 ## Claude Desktop
@@ -42,7 +42,7 @@ Claude Desktop is Anthropic's desktop application for conversational AI.
       "command": "python",
       "args": [
         "-m",
-        "mcp_server.cpp_mcp_server"
+        "mcp_server"
       ],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
@@ -59,7 +59,7 @@ Claude Desktop is Anthropic's desktop application for conversational AI.
   "mcpServers": {
     "cpp-analyzer": {
       "command": "C:\\path\\to\\clang_index_mcp\\mcp_env\\Scripts\\python.exe",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "C:\\path\\to\\clang_index_mcp",
       "env": {
         "PYTHONPATH": "C:\\path\\to\\clang_index_mcp"
@@ -93,7 +93,7 @@ Claude Code is the official VS Code extension by Anthropic.
       "command": "python",
       "args": [
         "-m",
-        "mcp_server.cpp_mcp_server"
+        "mcp_server"
       ],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
@@ -117,7 +117,7 @@ If you want to use the project's virtual environment:
   "claude.mcpServers": {
     "cpp-analyzer": {
       "command": "/absolute/path/to/clang_index_mcp/mcp_env/bin/python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/absolute/path/to/clang_index_mcp"
     }
   }
@@ -145,7 +145,7 @@ Cursor is an AI-first IDE built on VS Code.
       "command": "python",
       "args": [
         "-m",
-        "mcp_server.cpp_mcp_server"
+        "mcp_server"
       ],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
@@ -172,7 +172,7 @@ Create a `.cursorrules` or `mcp.json` file in your C++ project root:
   "mcpServers": {
     "cpp-analyzer": {
       "command": "/absolute/path/to/clang_index_mcp/mcp_env/bin/python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/absolute/path/to/clang_index_mcp"
     }
   }
@@ -199,7 +199,7 @@ Cline (formerly Claude Dev) is a VS Code extension for AI-assisted coding.
       "command": "python",
       "args": [
         "-m",
-        "mcp_server.cpp_mcp_server"
+        "mcp_server"
       ],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
@@ -243,7 +243,7 @@ Windsurf is an AI-native IDE for developers.
       "command": "python",
       "args": [
         "-m",
-        "mcp_server.cpp_mcp_server"
+        "mcp_server"
       ],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
@@ -282,7 +282,7 @@ Continue is an open-source VS Code extension for AI coding assistance.
       "command": "python",
       "args": [
         "-m",
-        "mcp_server.cpp_mcp_server"
+        "mcp_server"
       ],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
@@ -333,7 +333,7 @@ Error in LM Studio MCP bridge process: SSE error: Non-200 status code (405)
   "mcpServers": {
     "cpp-analyzer": {
       "command": "python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
         "PYTHONPATH": "/absolute/path/to/clang_index_mcp"
@@ -372,7 +372,7 @@ Error in LM Studio MCP bridge process: SSE error: Non-200 status code (405)
 
 **Recommended setup for LM Studio:**
 1. **Use HTTP or SSE transport** (fixes applied 2025-12-18) instead of stdio
-2. Start the server separately: `python -m mcp_server.cpp_mcp_server --transport http --port 8000`
+2. Start the server separately: `python -m mcp_server --transport http --port 8000`
 3. Configure LM Studio to connect to `http://127.0.0.1:8000/messages`
 4. This avoids LM Studio killing the server process during long-running indexing
 
@@ -408,7 +408,7 @@ Most MCP clients use a similar configuration format:
   "mcpServers": {
     "cpp-analyzer": {
       "command": "python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
         "PYTHONPATH": "/absolute/path/to/clang_index_mcp"
@@ -425,7 +425,7 @@ Most MCP clients use a similar configuration format:
   - Use virtual environment: `"/path/to/mcp_env/bin/python"`
 
 - **args**: Arguments to pass to Python
-  - `["-m", "mcp_server.cpp_mcp_server"]` - runs the module
+  - `["-m", "mcp_server"]` - runs the module
 
 - **cwd**: Working directory for the server
   - Must be the root of the clang_index_mcp repository
@@ -463,23 +463,23 @@ The examples above use **stdio** transport (standard input/output), which is the
 
 ```bash
 # Start HTTP server on default port 8000
-python -m mcp_server.cpp_mcp_server --transport http --port 8000
+python -m mcp_server --transport http --port 8000
 
 # Start on custom port
-python -m mcp_server.cpp_mcp_server --transport http --host 127.0.0.1 --port 9000
+python -m mcp_server --transport http --host 127.0.0.1 --port 9000
 
 # Allow external connections (use with caution)
-python -m mcp_server.cpp_mcp_server --transport http --host 0.0.0.0 --port 8000
+python -m mcp_server --transport http --host 0.0.0.0 --port 8000
 ```
 
 #### SSE Transport
 
 ```bash
 # Start SSE server on port 8080 (default is 8000)
-python -m mcp_server.cpp_mcp_server --transport sse --port 8080
+python -m mcp_server --transport sse --port 8080
 
 # Start on custom port
-python -m mcp_server.cpp_mcp_server --transport sse --host 127.0.0.1 --port 9000
+python -m mcp_server --transport sse --host 127.0.0.1 --port 9000
 ```
 
 ### MCP Client Configuration for HTTP/SSE
@@ -538,7 +538,7 @@ Type=simple
 User=youruser
 WorkingDirectory=/path/to/clang_index_mcp
 Environment="PYTHONPATH=/path/to/clang_index_mcp"
-ExecStart=/path/to/clang_index_mcp/mcp_env/bin/python -m mcp_server.cpp_mcp_server --transport http --host 127.0.0.1 --port 8000
+ExecStart=/path/to/clang_index_mcp/mcp_env/bin/python -m mcp_server --transport http --host 127.0.0.1 --port 8000
 Restart=on-failure
 
 [Install]
@@ -574,7 +574,7 @@ RUN python scripts/download_libclang.py
 EXPOSE 8000
 
 # Run server
-CMD ["python", "-m", "mcp_server.cpp_mcp_server", "--transport", "http", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "mcp_server", "--transport", "http", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
 Build and run:
@@ -590,7 +590,7 @@ docker run -d -p 8000:8000 --name cpp-analyzer cpp-analyzer-mcp
 screen -S cpp-analyzer
 cd /path/to/clang_index_mcp
 source mcp_env/bin/activate
-python -m mcp_server.cpp_mcp_server --transport http --port 8000
+python -m mcp_server --transport http --port 8000
 # Press Ctrl+A then D to detach
 
 # Reattach later
@@ -600,7 +600,7 @@ screen -r cpp-analyzer
 tmux new -s cpp-analyzer
 cd /path/to/clang_index_mcp
 source mcp_env/bin/activate
-python -m mcp_server.cpp_mcp_server --transport http --port 8000
+python -m mcp_server --transport http --port 8000
 # Press Ctrl+B then D to detach
 
 # Reattach later
@@ -713,7 +713,7 @@ python scripts/download_libclang.py
 **Solution:** Verify the server works standalone:
 ```bash
 cd /path/to/clang_index_mcp
-python -m mcp_server.cpp_mcp_server
+python -m mcp_server
 ```
 
 If it prints initialization messages and waits for input, it's working correctly.
@@ -765,7 +765,7 @@ You can specify a custom configuration file location:
   "mcpServers": {
     "cpp-analyzer": {
       "command": "python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/path/to/clang_index_mcp",
       "env": {
         "CPP_ANALYZER_CONFIG": "/path/to/custom/cpp-analyzer-config.json"
@@ -784,7 +784,7 @@ To enable debug output for troubleshooting:
   "mcpServers": {
     "cpp-analyzer": {
       "command": "python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/path/to/clang_index_mcp",
       "env": {
         "MCP_DEBUG": "1",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -395,7 +395,7 @@ self._processed: Dict[Tuple[str, str], str] = {}
 
 **Standalone (for testing)**:
 ```bash
-python -m mcp_server.cpp_mcp_server
+python -m mcp_server
 ```
 
 **With MCP Client**:
@@ -405,7 +405,7 @@ python -m mcp_server.cpp_mcp_server
   "mcpServers": {
     "clang-index": {
       "command": "python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/path/to/clang_index_mcp"
     }
   }
@@ -488,7 +488,7 @@ clang-index-mcp
 
 This is equivalent to:
 ```bash
-python -m mcp_server.cpp_mcp_server
+python -m mcp_server
 ```
 
 #### Package Configuration
@@ -720,7 +720,7 @@ Enable debug logging:
 ```bash
 export PYTHONUNBUFFERED=1
 export MCP_DEBUG=1
-python -m mcp_server.cpp_mcp_server
+python -m mcp_server
 ```
 
 ### libclang Debugging
@@ -751,7 +751,7 @@ rm -rf .mcp_cache/
 
 ```bash
 # Profile script
-python -m cProfile -o profile.stats -m mcp_server.cpp_mcp_server
+python -m cProfile -o profile.stats -m mcp_server
 
 # Analyze results
 python -m pstats profile.stats

--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,11 @@ check: format-check lint type-check ## Run all checks (format, lint, type)
 
 run: ## Run the MCP server
 	@echo "$(BLUE)Starting MCP server...$(NC)"
-	$(PYTHON) -m mcp_server._mcp.cpp_mcp_server
+	$(PYTHON) -m mcp_server
 
 dev: ## Run in development mode with debug output
 	@echo "$(BLUE)Starting MCP server in development mode...$(NC)"
-	MCP_DEBUG=1 PYTHONUNBUFFERED=1 $(PYTHON) -m mcp_server._mcp.cpp_mcp_server
+	MCP_DEBUG=1 PYTHONUNBUFFERED=1 $(PYTHON) -m mcp_server
 
 build: ## Build wheel package
 	@echo "$(BLUE)Building wheel package...$(NC)"

--- a/README.md
+++ b/README.md
@@ -48,19 +48,19 @@ The server supports multiple transport protocols:
 ### stdio (Default)
 Standard input/output transport for MCP client integration (Claude Desktop, etc.):
 ```bash
-python -m mcp_server.cpp_mcp_server
+python -m mcp_server
 ```
 
 ### HTTP (Streamable HTTP)
 RESTful HTTP transport for API access:
 ```bash
-python -m mcp_server.cpp_mcp_server --transport http --host 127.0.0.1 --port 8000
+python -m mcp_server --transport http --host 127.0.0.1 --port 8000
 ```
 
 ### SSE (Server-Sent Events)
 Real-time streaming transport for event-driven applications:
 ```bash
-python -m mcp_server.cpp_mcp_server --transport sse --host 127.0.0.1 --port 8000
+python -m mcp_server --transport sse --host 127.0.0.1 --port 8000
 ```
 
 For detailed HTTP/SSE usage, see **[HTTP_USAGE.md](docs/HTTP_USAGE.md)**
@@ -127,7 +127,7 @@ To use this with an MCP-compatible CLI Agent, add the server to your configurati
   "mcpServers": {
     "cpp-analyzer": {
       "command": "python",
-      "args": ["-m", "mcp_server.cpp_mcp_server"],
+      "args": ["-m", "mcp_server"],
       "cwd": "/absolute/path/to/clang_index_mcp",
       "env": {
         "PYTHONPATH": "/absolute/path/to/clang_index_mcp"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -253,10 +253,10 @@ xcode-select --install
 **1. Check for running processes:**
 ```bash
 # Linux/macOS
-ps aux | grep cpp_mcp_server
+ps aux | grep "python -m mcp_server"
 
 # Kill stale processes
-pkill -f cpp_mcp_server
+pkill -f "python -m mcp_server"
 ```
 
 **2. Remove stale lock files:**

--- a/docs/HTTP_USAGE.md
+++ b/docs/HTTP_USAGE.md
@@ -15,7 +15,7 @@ The server now supports three transport protocols:
 ### Default (stdio) Transport
 
 ```bash
-python3 -m mcp_server.cpp_mcp_server
+python3 -m mcp_server
 # or
 clang-index-mcp
 ```
@@ -23,7 +23,7 @@ clang-index-mcp
 ### HTTP Transport
 
 ```bash
-python3 -m mcp_server.cpp_mcp_server --transport http --port 8000
+python3 -m mcp_server --transport http --port 8000
 ```
 
 This starts an HTTP server on `http://127.0.0.1:8000` with the following endpoints:
@@ -35,7 +35,7 @@ This starts an HTTP server on `http://127.0.0.1:8000` with the following endpoin
 ### SSE Transport
 
 ```bash
-python3 -m mcp_server.cpp_mcp_server --transport sse --port 8080
+python3 -m mcp_server --transport sse --port 8080
 ```
 
 This starts an SSE server on `http://127.0.0.1:8080` with the following endpoints:
@@ -49,10 +49,10 @@ This starts an SSE server on `http://127.0.0.1:8080` with the following endpoint
 
 ```bash
 # HTTP on custom port
-python3 -m mcp_server.cpp_mcp_server --transport http --host 0.0.0.0 --port 9000
+python3 -m mcp_server --transport http --host 0.0.0.0 --port 9000
 
 # SSE on custom port
-python3 -m mcp_server.cpp_mcp_server --transport sse --host 127.0.0.1 --port 8888
+python3 -m mcp_server --transport sse --host 127.0.0.1 --port 8888
 ```
 
 ## Using the HTTP API
@@ -414,7 +414,7 @@ lsof -i :8000
 
 Try a different port:
 ```bash
-python3 -m mcp_server.cpp_mcp_server --transport http --port 9000
+python3 -m mcp_server --transport http --port 9000
 ```
 
 ### Session not found

--- a/docs/MACOS_LIBCLANG_DISCOVERY.md
+++ b/docs/MACOS_LIBCLANG_DISCOVERY.md
@@ -344,7 +344,7 @@ ls -la /opt/homebrew/Cellar/llvm/*/lib/libclang.dylib
 After implementing solution:
 ```bash
 # Should use system libclang (not bundled)
-python -m mcp_server.cpp_mcp_server --help
+python -m mcp_server --help
 # Check logs for "Discovered libclang: /Library/Developer/..."
 
 # Should not download

--- a/docs/MANUAL_TESTING_OBSERVATIONS.md
+++ b/docs/MANUAL_TESTING_OBSERVATIONS.md
@@ -470,7 +470,7 @@ Root Issue C: Error Reporting
 
 ```bash
 # Start server
-MCP_DEBUG=1 python -m mcp_server.cpp_mcp_server --transport sse --port 8000
+MCP_DEBUG=1 python -m mcp_server --transport sse --port 8000
 
 # Test Obs #2: Qualified names
 curl -s -X POST http://localhost:8000/mcp/v1/tools/call \

--- a/docs/testing/CLAUDE_TESTING_GUIDE.md
+++ b/docs/testing/CLAUDE_TESTING_GUIDE.md
@@ -151,17 +151,17 @@ python scripts/test_mcp_console.py /path/to/cpp/project
 **Basic startup:**
 ```bash
 # From project root
-python -m mcp_server.cpp_mcp_server --transport sse --port 8000
+python -m mcp_server --transport sse --port 8000
 ```
 
 **With debug logging:**
 ```bash
-MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server.cpp_mcp_server --transport sse --port 8000
+MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server --transport sse --port 8000
 ```
 
 **In background (for automated testing):**
 ```bash
-python -m mcp_server.cpp_mcp_server --transport sse --port 8000 &
+python -m mcp_server --transport sse --port 8000 &
 SERVER_PID=$!
 
 # Later, to stop:
@@ -183,7 +183,7 @@ INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 curl -s http://localhost:8000/health || echo "Server not running"
 
 # Check process
-ps aux | grep cpp_mcp_server
+ps aux | grep "python -m mcp_server"
 ```
 
 ---
@@ -595,7 +595,7 @@ curl -s -X POST http://localhost:8000/mcp/v1/tools/call \
 **Watch logs in real-time:**
 ```bash
 # Start server with debug logging and watch output
-MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server.cpp_mcp_server --transport sse --port 8000 2>&1 | tee server.log
+MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server --transport sse --port 8000 2>&1 | tee server.log
 ```
 
 **Grep for specific issues:**
@@ -615,7 +615,7 @@ tail -f server.log | grep -E "\[ERROR\]|\[WARNING\]"
 **Monitor file descriptors (Issue #3):**
 ```bash
 # Get server PID
-SERVER_PID=$(pgrep -f "cpp_mcp_server.*sse.*8000" | head -1)
+SERVER_PID=$(pgrep -f "python -m mcp_server.*sse.*8000" | head -1)
 
 # Monitor FD count (should stay stable at ~10-15)
 watch -n 2 "echo '=== FD Monitor ==='; \
@@ -811,13 +811,13 @@ echo "Headers found after refresh: $AFTER"
 ### Server Management
 ```bash
 # Start server
-python -m mcp_server.cpp_mcp_server --transport sse --port 8000
+python -m mcp_server --transport sse --port 8000
 
 # Start with debug
-MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server.cpp_mcp_server --transport sse --port 8000
+MCP_DEBUG=1 PYTHONUNBUFFERED=1 python -m mcp_server --transport sse --port 8000
 
 # Stop server (if running in background)
-pkill -f "cpp_mcp_server.*sse"
+pkill -f "python -m mcp_server.*sse"
 ```
 
 ### Common Tool Calls
@@ -838,10 +838,10 @@ curl -s -X POST http://localhost:8000/mcp/v1/tools/call -H "Content-Type: applic
 ### Monitoring
 ```bash
 # FD count
-lsof -p $(pgrep -f cpp_mcp_server) | wc -l
+lsof -p $(pgrep -f "python -m mcp_server") | wc -l
 
 # Memory usage
-ps -p $(pgrep -f cpp_mcp_server) -o rss=
+ps -p $(pgrep -f "python -m mcp_server") -o rss=
 
 # Watch logs
 tail -f server.log | grep -E "ERROR|WARNING"
@@ -890,7 +890,7 @@ lsof -i :8000
 kill $(lsof -t -i :8000)
 
 # Try different port
-python -m mcp_server.cpp_mcp_server --transport sse --port 8001
+python -m mcp_server --transport sse --port 8001
 ```
 
 ### Tool Call Returns Error
@@ -908,7 +908,7 @@ tail -50 server.log
 ### Timeout During Indexing
 ```bash
 # Check if indexing actually running
-ps aux | grep cpp_mcp_server
+ps aux | grep "python -m mcp_server"
 
 # Check progress
 curl -s -X POST http://localhost:8000/mcp/v1/tools/call \

--- a/docs/testing/MCP_CONSOLE_TESTING.md
+++ b/docs/testing/MCP_CONSOLE_TESTING.md
@@ -422,7 +422,7 @@ For advanced users who want to test the MCP protocol directly:
 
 ```bash
 # Start the server in stdio mode
-python -m mcp_server.cpp_mcp_server
+python -m mcp_server
 ```
 
 Then send JSON-RPC messages via stdin. Example messages are in `docs/mcp_protocol_examples.json`.

--- a/docs/testing/MCP_TESTING_SKILL.md
+++ b/docs/testing/MCP_TESTING_SKILL.md
@@ -603,7 +603,7 @@ curl -s -X POST http://localhost:8000/mcp/v1/tools/call \
 **stdio:**
 ```python
 # Send JSON-RPC via stdin, read from stdout
-echo '{"jsonrpc":"2.0","method":"tools/call",...}' | python -m mcp_server.cpp_mcp_server
+echo '{"jsonrpc":"2.0","method":"tools/call",...}' | python -m mcp_server
 ```
 
 **HTTP:**

--- a/docs/testing/TESTING_MACOS.md
+++ b/docs/testing/TESTING_MACOS.md
@@ -14,7 +14,7 @@ Exception: library file must be set before before using any other functionalitie
 
 The error occurs because:
 
-1. Tests import `mcp_server.cpp_mcp_server` which triggers module-level libclang initialization
+1. Tests import `mcp_server._mcp.cpp_mcp_server` which triggers module-level libclang initialization
 2. The libclang library path detection may fail on macOS if:
    - libclang is not installed
    - It's installed in a non-standard location
@@ -120,7 +120,7 @@ If you see libclang errors even after the fix:
 
 3. **Check which libclang is being used**:
    ```bash
-   python3 -m mcp_server.cpp_mcp_server --help 2>&1 | grep libclang
+   python3 -m mcp_server --help 2>&1 | grep libclang
    ```
 
 ### Server won't start with "library file must be set"

--- a/docs/testing/TEST_MCP_FAQ.md
+++ b/docs/testing/TEST_MCP_FAQ.md
@@ -154,7 +154,7 @@ A: No, builtin projects cannot be removed.
 1. Check if another server is running on port 8000:
    ```bash
    lsof -i :8000
-   pkill -f cpp_mcp_server
+   pkill -f "python -m mcp_server"
    ```
 
 2. Try a different protocol:
@@ -173,7 +173,7 @@ A: No, builtin projects cannot be removed.
 **Solutions:**
 1. Verify MCP server is installed:
    ```bash
-   python -m mcp_server.cpp_mcp_server --help
+   python -m mcp_server --help
    ```
 
 2. Check for Python errors in terminal output
@@ -200,7 +200,7 @@ A: No, builtin projects cannot be removed.
 
 2. Check if server is still running:
    ```bash
-   ps aux | grep cpp_mcp_server
+   ps aux | grep "python -m mcp_server"
    ```
 
 3. Use tier1 for faster testing

--- a/examples/compile_commands_example/README.md
+++ b/examples/compile_commands_example/README.md
@@ -179,19 +179,19 @@ make
 
 ```bash
 # Set the project directory
-python -m mcp.server.cpp_mcp_server set_project_directory /path/to/compile_commands_example
+python -m mcp.server set_project_directory /path/to/compile_commands_example
 
 # Get server status (should show compile commands enabled)
-python -m mcp.server.cpp_mcp_server get_server_status
+python -m mcp.server get_server_status
 
 # Search for functions
-python -m mcp.server.cpp_mcp_server search_functions ".*"
+python -m mcp.server search_functions ".*"
 
 # Get specific function info
-python -m mcp.server.cpp_mcp_server get_function_signature "get_greeting"
+python -m mcp.server get_function_signature "get_greeting"
 
 # Find function calls
-python -m mcp.server.cpp_mcp_server find_callees "main"
+python -m mcp.server find_callees "main"
 ```
 
 ### 3. Expected Results
@@ -264,13 +264,13 @@ Respects project-specific compiler configurations:
 
 ```bash
 # Check compile commands status
-python -m mcp.server.cpp_mcp_server get_server_status
+python -m mcp.server get_server_status
 
 # Refresh project (if compile commands changed)
-python -m mcp.server.cpp_mcp_server refresh_project
+python -m mcp.server refresh_project
 
 # Test with a specific file
-python -m mcp.server.cpp_mcp_server find_in_file "src/main.cpp" "main"
+python -m mcp.server find_in_file "src/main.cpp" "main"
 ```
 
 ## Advanced Configuration

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,15 @@
+"""Package entry point for the C++ Code Analysis MCP Server.
+
+Run with:
+    python -m mcp_server
+"""
+
+import asyncio
+
+from mcp_server._mcp.cpp_mcp_server import main
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/mcp_server/_core/http_server.py
+++ b/mcp_server/_core/http_server.py
@@ -5,6 +5,7 @@ Provides HTTP and Server-Sent Events transport support for the MCP server.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 from typing import Optional
@@ -102,6 +103,15 @@ class MCPHTTPServer:
     def _create_app(self) -> Starlette:
         """Create and configure the Starlette application."""
 
+        @contextlib.asynccontextmanager
+        async def lifespan(app: Starlette):
+            """Lifespan context that suppresses CancelledError during shutdown."""
+            try:
+                yield
+            except asyncio.CancelledError:
+                # Expected when the server task is cancelled during shutdown.
+                pass
+
         routes = [
             Route("/", self.handle_root, methods=["GET"]),
             Route("/health", self.handle_health, methods=["GET"]),
@@ -110,7 +120,7 @@ class MCPHTTPServer:
         if self.transport_type == "http":
             routes.append(Route("/messages", self.handle_http_message, methods=["POST"]))
 
-        app = Starlette(debug=True, routes=routes)
+        app = Starlette(debug=True, routes=routes, lifespan=lifespan)
 
         # For SSE transport, wrap the app with a middleware that intercepts
         # /sse and /messages paths and delegates to raw ASGI handlers

--- a/scripts/test_issue_003_fix.py
+++ b/scripts/test_issue_003_fix.py
@@ -48,7 +48,7 @@ def test_macos_paths_exist():
     print("=" * 60)
 
     # Check the source code for required paths
-    cpp_mcp_server_path = Path(__file__).parent / "mcp_server" / "cpp_mcp_server.py"
+    cpp_mcp_server_path = Path(__file__).parent / "mcp_server" / "_mcp" / "cpp_mcp_server.py"
     source = cpp_mcp_server_path.read_text()
 
     required_paths = [
@@ -78,7 +78,7 @@ def test_search_order():
     print("Test 3: Search order (LIBCLANG_PATH -> smart -> system -> bundled)")
     print("=" * 60)
 
-    cpp_mcp_server_path = Path(__file__).parent / "mcp_server" / "cpp_mcp_server.py"
+    cpp_mcp_server_path = Path(__file__).parent / "mcp_server" / "_mcp" / "cpp_mcp_server.py"
     source = cpp_mcp_server_path.read_text()
 
     # Find positions of each step
@@ -110,7 +110,7 @@ def test_xcrun_discovery():
     print("Test 4: xcrun smart discovery (macOS)")
     print("=" * 60)
 
-    cpp_mcp_server_path = Path(__file__).parent / "mcp_server" / "cpp_mcp_server.py"
+    cpp_mcp_server_path = Path(__file__).parent / "mcp_server" / "_mcp" / "cpp_mcp_server.py"
     source = cpp_mcp_server_path.read_text()
 
     has_xcrun = "xcrun" in source and "--find" in source and "clang" in source

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -23,7 +23,7 @@ class TestTransportSelection:
     def test_help_output(self):
         """Test that help output includes transport options."""
         result = subprocess.run(
-            [sys.executable, "-m", "mcp_server._mcp.cpp_mcp_server", "--help"], capture_output=True, text=True
+            [sys.executable, "-m", "mcp_server", "--help"], capture_output=True, text=True
         )
 
         assert result.returncode == 0
@@ -39,7 +39,7 @@ class TestTransportSelection:
         env = os.environ.copy()
         env["MCP_DISABLE_SESSION_RESUME"] = "true"
         result = subprocess.run(
-            [sys.executable, "-m", "mcp_server._mcp.cpp_mcp_server", "--transport", "invalid"],
+            [sys.executable, "-m", "mcp_server", "--transport", "invalid"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -63,7 +63,7 @@ class TestStdioTransport:
 
         # Start server process
         proc = subprocess.Popen(
-            [sys.executable, "-m", "mcp_server._mcp.cpp_mcp_server"],
+            [sys.executable, "-m", "mcp_server"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -103,7 +103,7 @@ class TestStdioTransport:
 
         # Start server process
         proc = subprocess.Popen(
-            [sys.executable, "-m", "mcp_server._mcp.cpp_mcp_server", "--transport", "stdio"],
+            [sys.executable, "-m", "mcp_server", "--transport", "stdio"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -151,7 +151,7 @@ class TestHTTPTransportIntegration:
             [
                 sys.executable,
                 "-m",
-                "mcp_server._mcp.cpp_mcp_server",
+                "mcp_server",
                 "--transport",
                 "http",
                 "--port",
@@ -214,7 +214,7 @@ class TestSSETransportIntegration:
             [
                 sys.executable,
                 "-m",
-                "mcp_server._mcp.cpp_mcp_server",
+                "mcp_server",
                 "--transport",
                 "sse",
                 "--port",


### PR DESCRIPTION
This PR adds a clean, idiomatic package entry point and fixes a shutdown traceback for HTTP/SSE transports.

## Changes

- **Add `mcp_server/__main__.py`** — the canonical command is now:
  ```bash
  python -m mcp_server
  ```
  Internal modules remain under `mcp_server/_mcp`.
- **Update `Makefile`** — `make run` and `make dev` use the new command.
- **Update tests** — `tests/test_transport_integration.py` invokes `mcp_server`; `scripts/test_issue_003_fix.py` points to the correct internal source path.
- **Update documentation** — README, CLIENT_SETUP, DEVELOPMENT, TROUBLESHOOTING, HTTP_USAGE, testing guides, and examples now reference `python -m mcp_server` and updated process-grep patterns.
- **Fix Ctrl+C traceback** — add a Starlette lifespan context manager that catches `asyncio.CancelledError` during shutdown, so HTTP/SSE transports exit without printing an ERROR traceback.

## Verification

- `make check` passes.
- `pytest tests/test_transport_integration.py` passes.
- `python -m mcp_server --transport sse --port 8125` + SIGINT exits with code 0 and no traceback.
- `python -m mcp_server --transport http --port 8126` + SIGINT exits with code 0 and no traceback.