### PR TITLE
refactor: fix Clean Architecture violations

### DIFF
--- a/clang_index_mcp/_compilation/clang_parser.py
+++ b/clang_index_mcp/_compilation/clang_parser.py
@@ -1,10 +1,9 @@
 import threading
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from clang.cindex import Index, TranslationUnit, TranslationUnitLoadError
 
 from .._core import diagnostics
-from .._persistence.persistence_context import PersistenceContext
 
 
 class ClangParser:
@@ -12,14 +11,18 @@ class ClangParser:
     Handles libclang Index and TranslationUnit management.
     """
 
-    def __init__(self, context: PersistenceContext):
+    def __init__(
+        self,
+        log_parse_error: Callable[[str, Exception, str, Optional[str], int], Any],
+    ):
         """
         Initialize ClangParser.
 
         Args:
-            context: Persistence context for access to cache_manager.
+            log_parse_error: Callback to log parse errors to cache.
+                Signature: (file_path, error, file_hash, compile_args_hash, retry_count) -> Any
         """
-        self.context = context
+        self._log_parse_error = log_parse_error
         self._thread_local = threading.local()
 
     def _get_thread_index(self) -> Index:
@@ -145,7 +148,7 @@ class ClangParser:
             cache_error_msg = full_error_msg[:200]
 
             parse_error = Exception(full_error_msg)
-            self.context.cache_manager.log_parse_error(
+            self._log_parse_error(
                 file_path, parse_error, current_hash, compile_args_hash, retry_count
             )
 

--- a/clang_index_mcp/_contexts/incremental_context.py
+++ b/clang_index_mcp/_contexts/incremental_context.py
@@ -1,0 +1,42 @@
+"""Incremental analysis context.
+
+Focused context for incremental analysis modules, replacing the dependency
+on the CppAnalyzer facade.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from typing import TYPE_CHECKING
+
+from .._core.concurrency_context import ConcurrencyContext
+from ..cpp_analyzer_config import CppAnalyzerConfig
+from .._persistence.cache_manager import CacheManager
+from .._persistence.cache_orchestrator import CacheOrchestrator
+from .._compilation.compilation_environment import CompilationEnvironment
+from .._symbols.symbol_index_store import SymbolIndexStore
+
+if TYPE_CHECKING:
+    from .._search.call_graph import CallGraphAnalyzer
+    from .._search.dependency_graph import DependencyGraphBuilder
+
+
+@dataclass
+class IncrementalContext:
+    """Services required by incremental analysis modules.
+
+    This context replaces the dependency on the CppAnalyzer facade,
+    providing only the specific services that incremental modules need.
+    """
+
+    project_root: Path
+    config: CppAnalyzerConfig
+    cache_manager: CacheManager
+    cache_orchestrator: CacheOrchestrator
+    compilation_env: CompilationEnvironment
+    symbol_store: SymbolIndexStore
+    concurrency: ConcurrencyContext
+    call_graph_analyzer: "CallGraphAnalyzer"
+    dependency_graph: "DependencyGraphBuilder"
+    config_file: Optional[str] = None

--- a/clang_index_mcp/_core/error_tracking_adapter.py
+++ b/clang_index_mcp/_core/error_tracking_adapter.py
@@ -1,53 +1,6 @@
-"""Adapter implementing the cache recovery port with concrete error tracking."""
+"""Backward-compatible re-export. Canonical location: _persistence.error_tracking_adapter."""
 
-from pathlib import Path
-from typing import Any, Dict, Optional, Union
-
-from .._core.error_tracking import ErrorTracker
-from .._persistence.recovery import RecoveryManager
-from .._persistence.ports.recovery import CacheRecoveryPort
-
-
-class ErrorTrackingAdapter:
-    """Adapter that exposes ErrorTracker + RecoveryManager as CacheRecoveryPort."""
-
-    def __init__(
-        self,
-        error_tracker: Optional[ErrorTracker] = None,
-        recovery_manager: Optional[RecoveryManager] = None,
-    ):
-        self._error_tracker = error_tracker or ErrorTracker()
-        self._recovery_manager = recovery_manager or RecoveryManager()
-
-    def record_operation(self, operation: str) -> None:
-        self._error_tracker.record_operation(operation)
-
-    def record_error(
-        self,
-        error_type: str,
-        error_message: str,
-        operation: str,
-        recoverable: bool = True,
-    ) -> bool:
-        return self._error_tracker.record_error(error_type, error_message, operation, recoverable)
-
-    def get_error_summary(self) -> Dict[str, Any]:
-        return self._error_tracker.get_error_summary()
-
-    def reset(self) -> None:
-        self._error_tracker.reset()
-
-    def backup_database(
-        self, db_path: Union[str, Path], backup_suffix: str = ".backup"
-    ) -> Optional[str]:
-        return self._recovery_manager.backup_database(db_path, backup_suffix)
-
-    def attempt_repair(self, db_path: Union[str, Path]) -> bool:
-        return self._recovery_manager.attempt_repair(db_path)
-
-    def clear_cache(self, cache_dir: Union[str, Path]) -> bool:
-        return self._recovery_manager.clear_cache(cache_dir)
-
-
-# Re-export for typing convenience
-CacheRecoveryPort.register(ErrorTrackingAdapter)
+from .._persistence.error_tracking_adapter import (  # noqa: F401
+    CacheRecoveryPort,
+    ErrorTrackingAdapter,
+)

--- a/clang_index_mcp/_incremental/change_handler.py
+++ b/clang_index_mcp/_incremental/change_handler.py
@@ -7,10 +7,10 @@ compile_commands.json changes, header changes, source changes, and removed files
 from typing import TYPE_CHECKING, Set
 
 if TYPE_CHECKING:
-    from ..cpp_analyzer import CppAnalyzer
+    from .._contexts.incremental_context import IncrementalContext
 
 
-def handle_compile_commands_change(analyzer: "CppAnalyzer") -> Set[str]:
+def handle_compile_commands_change(ctx: "IncrementalContext") -> Set[str]:
     """
     Handle compile_commands.json change.
 
@@ -27,10 +27,9 @@ def handle_compile_commands_change(analyzer: "CppAnalyzer") -> Set[str]:
 
     diagnostics.info("Handling compile_commands.json change...")
 
-    cc_manager = analyzer.context.compile_commands_manager
+    cc_manager = ctx.compilation_env.compile_commands_manager
     assert cc_manager is not None
-    cache_orchestrator = analyzer.context.cache_orchestrator
-    assert cache_orchestrator is not None
+    cache_orchestrator = ctx.cache_orchestrator
 
     old_commands = cc_manager.file_to_command_map.copy()
 
@@ -75,7 +74,7 @@ def handle_compile_commands_change(analyzer: "CppAnalyzer") -> Set[str]:
     return files_to_analyze
 
 
-def handle_header_change(analyzer: "CppAnalyzer", header_path: str) -> Set[str]:
+def handle_header_change(ctx: "IncrementalContext", header_path: str) -> Set[str]:
     """
     Handle header file change.
 
@@ -86,13 +85,11 @@ def handle_header_change(analyzer: "CppAnalyzer", header_path: str) -> Set[str]:
 
     diagnostics.info(f"Handling header change: {header_path}")
 
-    call_graph_service = analyzer.context.call_graph_service
-    assert call_graph_service is not None
-    cache_orchestrator = analyzer.context.cache_orchestrator
-    assert cache_orchestrator is not None
+    dependency_graph = ctx.dependency_graph
+    cache_orchestrator = ctx.cache_orchestrator
 
-    if call_graph_service.dependency_graph:
-        dependents = call_graph_service.dependency_graph.find_transitive_dependents(header_path)
+    if dependency_graph:
+        dependents = dependency_graph.find_transitive_dependents(header_path)
         diagnostics.info(f"Header {header_path} affects {len(dependents)} files")
     else:
         diagnostics.warning("No dependency graph, cannot determine affected files")
@@ -102,7 +99,7 @@ def handle_header_change(analyzer: "CppAnalyzer", header_path: str) -> Set[str]:
     return dependents
 
 
-def handle_source_change(analyzer: "CppAnalyzer", source_path: str) -> None:
+def handle_source_change(ctx: "IncrementalContext", source_path: str) -> None:
     """
     Handle source file change.
 
@@ -114,13 +111,12 @@ def handle_source_change(analyzer: "CppAnalyzer", source_path: str) -> None:
     diagnostics.debug(f"Handling source change: {source_path}")
 
 
-def remove_file(analyzer: "CppAnalyzer", file_path: str) -> None:
+def remove_file(ctx: "IncrementalContext", file_path: str) -> None:
     """Remove a deleted file from cache, indexes, and dependency graph."""
     from .._core import diagnostics
 
     diagnostics.info(f"Removing deleted file: {file_path}")
-    cache_orchestrator = analyzer.context.cache_orchestrator
-    assert cache_orchestrator is not None
+    cache_orchestrator = ctx.cache_orchestrator
     try:
         cache_orchestrator.remove_deleted_file(file_path)
     except Exception as e:

--- a/clang_index_mcp/_incremental/change_scanner.py
+++ b/clang_index_mcp/_incremental/change_scanner.py
@@ -11,20 +11,20 @@ Key Features:
 - Unified ChangeSet representation
 
 Usage:
-    scanner = ChangeScanner(analyzer)
+    scanner = ChangeScanner(ctx)
     changes = scanner.scan_for_changes()
 
     if not changes.is_empty():
         # Process changes
         for added_file in changes.added_files:
-            analyzer.index_file(added_file)
+            ...
 """
 
 import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Set, cast
+from typing import TYPE_CHECKING, Optional, Set, cast
 
 from .._core.file_scanner import FileScanner
 
@@ -33,6 +33,9 @@ try:
     from .._core import diagnostics
 except ImportError:
     import diagnostics  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from .._contexts.incremental_context import IncrementalContext
 
 
 class ChangeType(Enum):
@@ -130,17 +133,17 @@ class ChangeScanner:
     - compile_commands.json changes
     - Header file modifications
 
-    Uses CppAnalyzer's cache and file scanner to determine what changed.
+    Uses IncrementalContext's cache and file scanner to determine what changed.
     """
 
-    def __init__(self, analyzer):
+    def __init__(self, ctx: "IncrementalContext"):
         """
         Initialize change scanner.
 
         Args:
-            analyzer: CppAnalyzer instance with cache and file scanner
+            ctx: IncrementalContext with cache and file scanner
         """
-        self.analyzer = analyzer
+        self.ctx = ctx
 
     def scan_for_changes(self) -> ChangeSet:
         """
@@ -185,7 +188,7 @@ class ChangeScanner:
 
     def _scan_source_files(self, changeset: ChangeSet) -> None:
         """Detect added and modified source files, excluding headers."""
-        all_cpp_files = self.analyzer.context.file_scanner.find_cpp_files()
+        all_cpp_files = self.ctx.compilation_env.file_scanner.find_cpp_files()
         current_source_files = set()
         for file_path in all_cpp_files:
             if file_path.endswith(tuple(FileScanner.HEADER_EXTENSIONS)):
@@ -205,7 +208,8 @@ class ChangeScanner:
 
     def _scan_tracked_headers(self, changeset: ChangeSet) -> None:
         """Detect modified or deleted tracked headers."""
-        tracked_headers = self.analyzer.context.cache_orchestrator.get_processed_headers()
+        cache_orchestrator = self.ctx.cache_orchestrator
+        tracked_headers = cache_orchestrator.get_processed_headers()
         for header_path, tracked_hash in tracked_headers.items():
             normalized_header = os.path.realpath(header_path)
 
@@ -215,9 +219,7 @@ class ChangeScanner:
                 continue
 
             try:
-                current_hash = self.analyzer.context.cache_orchestrator.get_file_hash(
-                    normalized_header
-                )
+                current_hash = cache_orchestrator.get_file_hash(normalized_header)
                 if current_hash != tracked_hash:
                     changeset.modified_headers.add(normalized_header)
                     diagnostics.debug(f"Detected modified header: {normalized_header}")
@@ -244,21 +246,22 @@ class ChangeScanner:
     def _get_cached_hash(self, file_path: str) -> Optional[str]:
         """Get cached hash from database or in-memory cache. Returns None if not found."""
         try:
-            metadata = self.analyzer.cache_manager.backend.get_file_metadata(file_path)
+            backend = self.ctx.cache_manager.backend
+            metadata = backend.get_file_metadata(file_path)  # type: ignore[attr-defined]
             if metadata:
                 return str(metadata.get("file_hash", ""))
         except Exception as e:
             diagnostics.warning(f"Error getting metadata for {file_path}: {e}")
 
-        if self.analyzer.context.symbol_store.has_file_hash(file_path):
-            return str(self.analyzer.context.symbol_store.get_file_hash(file_path))
+        if self.ctx.symbol_store.has_file_hash(file_path):
+            return str(self.ctx.symbol_store.get_file_hash(file_path))
 
         return None
 
     def _compare_with_cached_hash(self, file_path: str, cached_hash: str) -> ChangeType:
         """Compare current file hash with cached hash."""
         try:
-            current_hash = self.analyzer.context.cache_orchestrator.get_file_hash(file_path)
+            current_hash = self.ctx.cache_orchestrator.get_file_hash(file_path)
             if current_hash != cached_hash:
                 return ChangeType.MODIFIED
             return ChangeType.UNCHANGED
@@ -279,10 +282,10 @@ class ChangeScanner:
         Algorithm:
             1. Query cache manager for file metadata (database)
             2. If not in database, fallback to in-memory file_hashes
-            3. If not in cache at all → ADDED
+            3. If not in cache at all -> ADDED
             4. If in cache, compare MD5 hash
-            5. Hash mismatch → MODIFIED
-            6. Hash match → UNCHANGED
+            5. Hash mismatch -> MODIFIED
+            6. Hash match -> UNCHANGED
         """
         cached_hash = self._get_cached_hash(file_path)
         if cached_hash is None:
@@ -298,20 +301,21 @@ class ChangeScanner:
         Returns:
             True if changed, False if unchanged or doesn't exist
         """
-        compile_commands_config = self.analyzer.config.get_compile_commands_config()
-        cc_path = self.analyzer.project_root / compile_commands_config.compile_commands_path
+        ctx = self.ctx
+        compile_commands_config = ctx.config.get_compile_commands_config()
+        cc_path = ctx.project_root / compile_commands_config.compile_commands_path
 
         if not cc_path.exists():
             # If file doesn't exist, check if it existed before
             # (stored hash is non-empty means it existed)
-            return bool(self.analyzer.context.cache_orchestrator.compile_commands_hash)
+            return bool(ctx.cache_orchestrator.compile_commands_hash)
 
         # Calculate current hash
         try:
-            current_hash = self.analyzer.context.cache_orchestrator.get_file_hash(str(cc_path))
+            current_hash = ctx.cache_orchestrator.get_file_hash(str(cc_path))
 
             # Compare with stored hash
-            if current_hash != self.analyzer.context.cache_orchestrator.compile_commands_hash:
+            if current_hash != ctx.cache_orchestrator.compile_commands_hash:
                 return True
 
             return False
@@ -332,10 +336,9 @@ class ChangeScanner:
         """
         try:
             # Query all files from file_metadata table
-            if hasattr(self.analyzer.cache_manager.backend, "get_all_cached_file_paths"):
-                return cast(
-                    Set[str], self.analyzer.cache_manager.backend.get_all_cached_file_paths()
-                )
+            backend = self.ctx.cache_manager.backend
+            if hasattr(backend, "get_all_cached_file_paths"):
+                return cast(Set[str], backend.get_all_cached_file_paths())
             else:
                 # Cached file list requires SQLite backend
                 # Return empty set (will trigger full re-analysis)

--- a/clang_index_mcp/_incremental/compile_args_resolver.py
+++ b/clang_index_mcp/_incremental/compile_args_resolver.py
@@ -8,13 +8,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List
 
 if TYPE_CHECKING:
-    from ..cpp_analyzer import CppAnalyzer
+    from .._contexts.incremental_context import IncrementalContext
 
 
-def get_file_compile_args(analyzer: "CppAnalyzer", file_list: List[str]) -> Dict[str, List[str]]:
+def get_file_compile_args(ctx: "IncrementalContext", file_list: List[str]) -> Dict[str, List[str]]:
     """Precompute compile arguments for a list of files."""
-    compilation_env = analyzer.context.compilation_env
-    assert compilation_env is not None
+    compilation_env = ctx.compilation_env
     file_compile_args = {}
     for file_path in file_list:
         file_path_obj = Path(file_path)

--- a/clang_index_mcp/_incremental/incremental_analyzer.py
+++ b/clang_index_mcp/_incremental/incremental_analyzer.py
@@ -11,7 +11,7 @@ Key Features:
 - Provides detailed analysis results
 
 Usage:
-    incremental = IncrementalAnalyzer(analyzer)
+    incremental = IncrementalAnalyzer(ctx)
     result = incremental.perform_incremental_analysis()
 
     if result.files_analyzed > 0:
@@ -20,7 +20,7 @@ Usage:
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Set
+from typing import TYPE_CHECKING, Callable, Optional, Set
 
 # Handle both package and script imports
 try:
@@ -36,7 +36,9 @@ except ImportError:
     from indexing_callbacks import IndexingCallbacks  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
-    from ..cpp_analyzer import CppAnalyzer
+    from concurrent.futures import Executor
+
+    from .._contexts.incremental_context import IncrementalContext
 
 
 @dataclass
@@ -73,7 +75,7 @@ class IncrementalAnalyzer:
     This is the main entry point for all incremental updates. It:
     1. Scans for changes using ChangeScanner
     2. Determines affected files using DependencyGraphBuilder
-    3. Coordinates re-analysis via CppAnalyzer
+    3. Coordinates re-analysis via worker pool
     4. Provides detailed results
 
     The analysis prioritizes changes to minimize redundant work:
@@ -82,15 +84,24 @@ class IncrementalAnalyzer:
     - Source changes are isolated
     """
 
-    def __init__(self, analyzer: "CppAnalyzer"):
+    def __init__(
+        self,
+        ctx: "IncrementalContext",
+        is_interrupted: Optional[Callable[[], bool]] = None,
+        shutdown_executor: Optional[Callable[["Executor", str], None]] = None,
+    ):
         """
         Initialize incremental analyzer.
 
         Args:
-            analyzer: CppAnalyzer instance with all components initialized
+            ctx: IncrementalContext with all required services
+            is_interrupted: Callback to check if analysis was interrupted
+            shutdown_executor: Callback to shut down an executor
         """
-        self.analyzer = analyzer
-        self.scanner = ChangeScanner(analyzer)
+        self.ctx = ctx
+        self.scanner = ChangeScanner(ctx)
+        self._is_interrupted = is_interrupted or (lambda: False)
+        self._shutdown_executor = shutdown_executor
 
     def perform_incremental_analysis(
         self,
@@ -193,89 +204,19 @@ class IncrementalAnalyzer:
 
     def _handle_compile_commands_change(self) -> Set[str]:
         """Handle compile_commands.json change."""
-        return change_handler.handle_compile_commands_change(self.analyzer)
+        return change_handler.handle_compile_commands_change(self.ctx)
 
     def _handle_header_change(self, header_path: str) -> Set[str]:
         """Handle header file change."""
-        return change_handler.handle_header_change(self.analyzer, header_path)
+        return change_handler.handle_header_change(self.ctx, header_path)
 
     def _handle_source_change(self, source_path: str) -> None:
         """Handle source file change."""
-        return change_handler.handle_source_change(self.analyzer, source_path)
+        return change_handler.handle_source_change(self.ctx, source_path)
 
     def _remove_file(self, file_path: str) -> None:
         """Remove a deleted file from cache, indexes, and dependency graph."""
-        return change_handler.remove_file(self.analyzer, file_path)
-
-    def _remove_symbol_from_index(self, symbol) -> None:
-        """Remove a symbol from the appropriate index (class or function)."""
-        from .._incremental.symbol_merger import remove_symbol_from_index
-
-        return remove_symbol_from_index(self.analyzer, symbol)
-
-    def _handle_definition_wins(self, symbol, existing) -> bool:
-        """Apply 'definition wins' rule for duplicate symbols."""
-        from .._incremental.symbol_merger import handle_definition_wins
-
-        return handle_definition_wins(self.analyzer, symbol, existing)
-
-    def _add_symbol_to_indices(self, symbol) -> None:
-        """Add a symbol to the analyzer's indices."""
-        from .._incremental.symbol_merger import add_symbol_to_indices
-
-        return add_symbol_to_indices(self.analyzer, symbol)
-
-    def _merge_symbols(self, symbols) -> None:
-        """Merge symbols from a worker process into the main analyzer index."""
-        from .._incremental.symbol_merger import merge_symbols
-
-        return merge_symbols(self.analyzer, symbols)
-
-    def _get_file_compile_args(self, file_list):
-        """Precompute compile arguments for a list of files."""
-        from .._incremental.compile_args_resolver import get_file_compile_args
-
-        return get_file_compile_args(self.analyzer, file_list)
-
-    def _create_executor(self, max_workers: int):
-        """Create a process pool executor and its spawn context."""
-        return worker_orchestrator.create_executor(max_workers)
-
-    def _process_future_result(self, result, file_path: str):
-        """Process the result from a future and merge it into the analyzer."""
-        return worker_orchestrator.process_future_result(self.analyzer, result, file_path)
-
-    def _report_progress(
-        self,
-        progress_callback,
-        i: int,
-        total: int,
-        analyzed: int,
-        failed: int,
-        start_time: float,
-        file_path: str,
-    ) -> None:
-        """Calculate and report indexing progress via callback."""
-        return worker_orchestrator.report_progress(
-            progress_callback, i, total, analyzed, failed, start_time, file_path
-        )
-
-    def _submit_tasks(self, executor, file_list):
-        """Submit re-analysis tasks to the process pool executor."""
-        return worker_orchestrator.submit_tasks(self.analyzer, executor, file_list)
-
-    def _process_loop(
-        self,
-        executor,
-        future_to_file,
-        start_time: float,
-        total: int,
-        callbacks: Optional[IndexingCallbacks],
-    ):
-        """Process results from futures in a loop."""
-        return worker_orchestrator.process_loop(
-            self.analyzer, executor, future_to_file, start_time, total, callbacks
-        )
+        return change_handler.remove_file(self.ctx, file_path)
 
     def _reanalyze_files(
         self,
@@ -284,4 +225,11 @@ class IncrementalAnalyzer:
         callbacks: Optional[IndexingCallbacks] = None,
     ) -> int:
         """Re-analyze a set of files using parallel processing."""
-        return worker_orchestrator.reanalyze_files(self.analyzer, files, start_time, callbacks)
+        return worker_orchestrator.reanalyze_files(
+            self.ctx,
+            files,
+            start_time,
+            callbacks,
+            is_interrupted=self._is_interrupted,
+            shutdown_executor=self._shutdown_executor,
+        )

--- a/clang_index_mcp/_incremental/symbol_merger.py
+++ b/clang_index_mcp/_incremental/symbol_merger.py
@@ -8,17 +8,15 @@ deduplication rule.
 from typing import TYPE_CHECKING, Any, List
 
 if TYPE_CHECKING:
-    from ..cpp_analyzer import CppAnalyzer
+    from .._contexts.incremental_context import IncrementalContext
 
 
-def remove_symbol_from_index(analyzer: "CppAnalyzer", symbol: Any) -> None:
+def remove_symbol_from_index(ctx: "IncrementalContext", symbol: Any) -> None:
     """Remove a symbol from the appropriate index (class or function)."""
-    symbol_store = analyzer.context.symbol_store
-    assert symbol_store is not None
-    symbol_store.remove_symbol_from_indexes(symbol)
+    ctx.symbol_store.remove_symbol_from_indexes(symbol)
 
 
-def handle_definition_wins(analyzer: "CppAnalyzer", symbol: Any, existing: Any) -> bool:
+def handle_definition_wins(ctx: "IncrementalContext", symbol: Any, existing: Any) -> bool:
     """
     Apply 'definition wins' rule for duplicate symbols.
 
@@ -26,29 +24,26 @@ def handle_definition_wins(analyzer: "CppAnalyzer", symbol: Any, existing: Any) 
     False if the existing symbol should be replaced.
     """
     if symbol.is_definition and not existing.is_definition:
-        remove_symbol_from_index(analyzer, existing)
+        remove_symbol_from_index(ctx, existing)
         return False
     return True
 
 
-def add_symbol_to_indices(analyzer: "CppAnalyzer", symbol: Any) -> None:
+def add_symbol_to_indices(ctx: "IncrementalContext", symbol: Any) -> None:
     """Add a symbol to the analyzer's indices."""
-    symbol_store = analyzer.context.symbol_store
-    assert symbol_store is not None
-    symbol_store.add_symbol_to_indexes(symbol)
+    ctx.symbol_store.add_symbol_to_indexes(symbol)
 
 
-def merge_symbols(analyzer: "CppAnalyzer", symbols: List[Any]) -> None:
+def merge_symbols(ctx: "IncrementalContext", symbols: List[Any]) -> None:
     """Merge symbols from a worker process into the main analyzer index."""
-    store = analyzer.context.symbol_store
-    assert store is not None
-    with analyzer.context.concurrency.index_lock:
+    store = ctx.symbol_store
+    with ctx.concurrency.index_lock:
         for symbol in symbols:
             skip_symbol = False
             if symbol.usr and store.contains_usr(symbol.usr):
                 existing = store.get_symbol_by_usr(symbol.usr)
                 assert existing is not None
-                skip_symbol = handle_definition_wins(analyzer, symbol, existing)
+                skip_symbol = handle_definition_wins(ctx, symbol, existing)
 
             if not skip_symbol:
-                add_symbol_to_indices(analyzer, symbol)
+                add_symbol_to_indices(ctx, symbol)

--- a/clang_index_mcp/_incremental/worker_orchestrator.py
+++ b/clang_index_mcp/_incremental/worker_orchestrator.py
@@ -248,14 +248,17 @@ def _run_analysis_loop(
 ) -> int:
     """Execute the analysis loop with executor lifecycle management."""
     from .._core import diagnostics
+    from .._indexing.worker_pool import _init_worker
 
     executor: Optional[Executor] = None
     max_workers = os.cpu_count() or 4
     try:
         if mp_context:
-            executor = ProcessPoolExecutor(max_workers=max_workers, mp_context=mp_context)
+            executor = ProcessPoolExecutor(
+                max_workers=max_workers, mp_context=mp_context, initializer=_init_worker
+            )
         else:
-            executor = ProcessPoolExecutor(max_workers=max_workers)
+            executor = ProcessPoolExecutor(max_workers=max_workers, initializer=_init_worker)
 
         future_to_file = submit_tasks(ctx, executor, file_list)
         analyzed, _failed = process_loop(

--- a/clang_index_mcp/_incremental/worker_orchestrator.py
+++ b/clang_index_mcp/_incremental/worker_orchestrator.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type
 
 if TYPE_CHECKING:
-    from ..cpp_analyzer import CppAnalyzer
+    from .._contexts.incremental_context import IncrementalContext
     from .._symbols.indexing_callbacks import IndexingCallbacks
 
 
@@ -35,27 +35,24 @@ def create_executor(
 
 
 def process_future_result(
-    analyzer: "CppAnalyzer", result: Any, file_path: str
+    ctx: "IncrementalContext", result: Any, file_path: str
 ) -> Tuple[bool, bool]:
     """Process the result from a future and merge it into the analyzer."""
     from .._incremental.symbol_merger import merge_symbols
 
-    call_graph_service = analyzer.context.call_graph_service
-    assert call_graph_service is not None
-    cache_orchestrator = analyzer.context.cache_orchestrator
-    assert cache_orchestrator is not None
-    symbol_store = analyzer.context.symbol_store
-    assert symbol_store is not None
+    call_graph_analyzer = ctx.call_graph_analyzer
+    cache_orchestrator = ctx.cache_orchestrator
+    symbol_store = ctx.symbol_store
 
     # ProcessPoolExecutor returns (file_path, success, was_cached, symbols, call_sites, processed_headers)
     _, success, was_cached, symbols, call_sites, processed_headers = result
 
     if success and symbols:
-        merge_symbols(analyzer, symbols)
+        merge_symbols(ctx, symbols)
 
     if call_sites:
         for cs_dict in call_sites:
-            call_graph_service.call_graph_analyzer.add_call(
+            call_graph_analyzer.add_call(
                 cs_dict["caller_usr"],
                 cs_dict["callee_usr"],
                 cs_dict["file"],
@@ -112,7 +109,7 @@ def report_progress(
 
 
 def submit_tasks(
-    analyzer: "CppAnalyzer",
+    ctx: "IncrementalContext",
     executor: Executor,
     file_list: List[str],
 ) -> Dict[Any, str]:
@@ -123,16 +120,11 @@ def submit_tasks(
     from .._indexing.worker_pool import _process_file_worker
     from .._incremental.compile_args_resolver import get_file_compile_args
 
-    project_root = str(analyzer.project_root)
-    config_file_str = (
-        str(analyzer.project_identity.config_file_path)
-        if analyzer.project_identity.config_file_path
-        else None
-    )
-    compilation_env = analyzer.context.compilation_env
-    assert compilation_env is not None
+    project_root = str(ctx.project_root)
+    config_file_str = ctx.config_file
+    compilation_env = ctx.compilation_env
     include_dependencies = compilation_env.include_dependencies
-    file_compile_args = get_file_compile_args(analyzer, file_list)
+    file_compile_args = get_file_compile_args(ctx, file_list)
 
     return {
         executor.submit(
@@ -151,12 +143,14 @@ def submit_tasks(
 
 
 def process_loop(
-    analyzer: "CppAnalyzer",
+    ctx: "IncrementalContext",
     executor: Executor,
     future_to_file: Dict[Any, str],
     start_time: float,
     total: int,
     callbacks: Optional["IndexingCallbacks"],
+    is_interrupted: Callable[[], bool],
+    shutdown_executor: Callable[[Executor, str], None],
 ) -> Tuple[int, int]:
     """Process results from futures in a loop."""
     from .._core import diagnostics
@@ -165,7 +159,7 @@ def process_loop(
     failed = 0
 
     for i, future in enumerate(as_completed(future_to_file)):
-        if getattr(analyzer, "_interrupted", False) is True:
+        if is_interrupted():
             for f in future_to_file:
                 f.cancel()
             diagnostics.info("Incremental refresh interrupted by request")
@@ -177,7 +171,7 @@ def process_loop(
         file_path = future_to_file[future]
         try:
             result = future.result()
-            success, was_cached = process_future_result(analyzer, result, file_path)
+            success, was_cached = process_future_result(ctx, result, file_path)
 
             if success:
                 analyzed += 1
@@ -197,10 +191,12 @@ def process_loop(
 
 
 def reanalyze_files(
-    analyzer: "CppAnalyzer",
+    ctx: "IncrementalContext",
     files: Set[str],
     start_time: float,
     callbacks: Optional["IndexingCallbacks"] = None,
+    is_interrupted: Optional[Callable[[], bool]] = None,
+    shutdown_executor: Optional[Callable[[Executor, str], None]] = None,
 ) -> int:
     """
     Re-analyze a set of files using parallel processing.
@@ -212,38 +208,70 @@ def reanalyze_files(
 
     from .._core import diagnostics
 
-    analyzed = 0
-    failed = 0
+    if is_interrupted is None:
+
+        def _never_interrupted() -> bool:
+            return False
+
+        is_interrupted = _never_interrupted
+    if shutdown_executor is None:
+
+        def _default_shutdown(executor: Executor, name: str) -> None:
+            try:
+                executor.shutdown(wait=False)
+            except Exception:
+                pass
+
+        shutdown_executor = _default_shutdown
+
     total = len(files)
     file_list = list(files)
 
-    max_workers = getattr(analyzer, "max_workers", None)
-    if max_workers is None or not isinstance(max_workers, int):
-        max_workers = os.cpu_count() or 4
-
+    max_workers = os.cpu_count() or 4
     mp_context, _, msg = create_executor(max_workers)
     diagnostics.debug(msg)
 
+    return _run_analysis_loop(
+        ctx, file_list, start_time, total, callbacks, is_interrupted, shutdown_executor, mp_context
+    )
+
+
+def _run_analysis_loop(
+    ctx: "IncrementalContext",
+    file_list: List[str],
+    start_time: float,
+    total: int,
+    callbacks: Optional["IndexingCallbacks"],
+    is_interrupted: Callable[[], bool],
+    shutdown_executor: Callable[[Executor, str], None],
+    mp_context: Optional[multiprocessing.context.BaseContext],
+) -> int:
+    """Execute the analysis loop with executor lifecycle management."""
+    from .._core import diagnostics
+
     executor: Optional[Executor] = None
+    max_workers = os.cpu_count() or 4
     try:
         if mp_context:
             executor = ProcessPoolExecutor(max_workers=max_workers, mp_context=mp_context)
         else:
             executor = ProcessPoolExecutor(max_workers=max_workers)
 
-        future_to_file = submit_tasks(analyzer, executor, file_list)
-        analyzed, failed = process_loop(
-            analyzer,
+        future_to_file = submit_tasks(ctx, executor, file_list)
+        analyzed, _failed = process_loop(
+            ctx,
             executor,
             future_to_file,
             start_time,
             total,
             callbacks,
+            is_interrupted,
+            shutdown_executor,
         )
     except KeyboardInterrupt:
         diagnostics.info("\nIncremental refresh interrupted")
         if executor is not None:
-            analyzer._shutdown_executor(executor, name="Incremental Refresh")  # type: ignore[attr-defined]
+            shutdown_executor(executor, "Incremental Refresh")
         raise
     finally:
         if executor is not None:

--- a/clang_index_mcp/_indexing/worker_pool.py
+++ b/clang_index_mcp/_indexing/worker_pool.py
@@ -4,8 +4,10 @@ Worker pool and parallel execution management for C++ Analyzer.
 
 import atexit
 import gc
+import io
 import multiprocessing
 import os
+import signal
 import sys
 import time
 from concurrent.futures import (
@@ -27,12 +29,36 @@ except ImportError:
 _worker_analyzer = None
 
 
+def _init_worker():
+    """Initializer for each worker process.
+
+    Ignores SIGINT so that Ctrl+C in the parent does not produce
+    KeyboardInterrupt tracebacks in workers.  The parent controls
+    worker lifetime via SIGTERM/SIGKILL.
+    """
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
 def _cleanup_worker_analyzer():
-    """Ensure worker analyzer resources are released on process exit."""
+    """Ensure worker analyzer resources are released on process exit.
+
+    Suppresses stderr during close to avoid noisy libclang cleanup
+    errors (_CXString.__del__, cursor visitor assertions) that occur
+    when the interpreter is shutting down and C-level objects are
+    garbage-collected after libclang's shared library may already be
+    partially torn down.
+    """
     global _worker_analyzer
     if _worker_analyzer is not None:
-        _worker_analyzer.close()
-        _worker_analyzer = None
+        saved = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            _worker_analyzer.close()
+        except Exception:
+            pass
+        finally:
+            sys.stderr = saved
+            _worker_analyzer = None
 
 
 def _process_file_worker(spec: IndexingTaskSpec):
@@ -94,8 +120,13 @@ def _process_file_worker(spec: IndexingTaskSpec):
     # Clean up worker indexes to prevent memory leaks (Issue #14)
     context.symbol_store.clear_all_indexes()
 
-    # Force garbage collection to free TranslationUnit objects
-    gc.collect()
+    # Force garbage collection to free TranslationUnit objects.
+    # Wrap in try/except because libclang's __del__ methods may raise
+    # if the C library state is inconsistent after a partial parse.
+    try:
+        gc.collect()
+    except Exception:
+        pass
 
     return (spec.file_path, success, was_cached, symbols, call_sites, processed_headers)
 
@@ -114,11 +145,16 @@ class WorkerPoolManager:
             self.mp_context = multiprocessing.get_context("spawn")
             diagnostics.debug(f"Using ProcessPoolExecutor (spawn) with {self.max_workers} workers")
             self.executor = ProcessPoolExecutor(
-                max_workers=self.max_workers, mp_context=self.mp_context
+                max_workers=self.max_workers,
+                mp_context=self.mp_context,
+                initializer=_init_worker,
             )
         except Exception as e:
             diagnostics.warning(f"Failed to use 'spawn' context: {e}. Falling back to default.")
-            self.executor = ProcessPoolExecutor(max_workers=self.max_workers)
+            self.executor = ProcessPoolExecutor(
+                max_workers=self.max_workers,
+                initializer=_init_worker,
+            )
 
         return self.executor
 

--- a/clang_index_mcp/_mcp/tool_call_logger.py
+++ b/clang_index_mcp/_mcp/tool_call_logger.py
@@ -16,7 +16,7 @@ from collections import Counter, deque
 from pathlib import Path
 from typing import Any, Dict, List
 
-from .._search.smart_fallback import _PROTOTYPE_PATTERN, _looks_like_signature
+from .._search.smart_fallback import PROTOTYPE_PATTERN, looks_like_signature
 
 # Regex metacharacters that distinguish regex patterns from plain names
 _REGEX_META = re.compile(r"[.*+?\[\]{}()|\\^$]")
@@ -43,9 +43,9 @@ def _classify_pattern(pattern: str) -> str:
     4. regex — has regex metacharacters
     5. plain_name — simple identifier
     """
-    if _looks_like_signature(pattern):
+    if looks_like_signature(pattern):
         return "signature_like"
-    if _PROTOTYPE_PATTERN.search(pattern):
+    if PROTOTYPE_PATTERN.search(pattern):
         return "prototype_like"
     has_colons = "::" in pattern
     has_meta = bool(_REGEX_META.search(pattern))

--- a/clang_index_mcp/_mcp/transport/http_server.py
+++ b/clang_index_mcp/_mcp/transport/http_server.py
@@ -125,30 +125,33 @@ class MCPHTTPServer:
         # For SSE transport, wrap the app with a middleware that intercepts
         # /sse and /messages paths and delegates to raw ASGI handlers
         if self.transport_type == "sse":
-            original_app = app
-
-            async def sse_middleware(scope, receive, send):
-                """Middleware that intercepts SSE paths and delegates to raw ASGI handlers."""
-                if scope["type"] == "http":
-                    path = scope["path"]
-                    method = scope["method"]
-
-                    # Intercept GET /sse
-                    if path == "/sse" and method == "GET":
-                        await self.handle_sse_endpoint(scope, receive, send)
-                        return
-
-                    # Intercept POST /messages
-                    if path == "/messages" and method == "POST":
-                        await self.handle_messages_endpoint(scope, receive, send)
-                        return
-
-                # Pass through to Starlette for all other routes
-                await original_app(scope, receive, send)
-
-            return sse_middleware  # type: ignore[return-value]
+            return self._wrap_with_sse_middleware(app)  # type: ignore[return-value,no-any-return]
 
         return app
+
+    def _wrap_with_sse_middleware(self, original_app: Starlette):
+        """Wrap a Starlette app with SSE path interception middleware."""
+
+        async def sse_middleware(scope, receive, send):
+            """Middleware that intercepts SSE paths and delegates to raw ASGI handlers."""
+            if scope["type"] == "http":
+                path = scope["path"]
+                method = scope["method"]
+
+                if path == "/sse" and method == "GET":
+                    await self.handle_sse_endpoint(scope, receive, send)
+                    return
+
+                if path == "/messages" and method == "POST":
+                    await self.handle_messages_endpoint(scope, receive, send)
+                    return
+
+            try:
+                await original_app(scope, receive, send)
+            except asyncio.CancelledError:
+                logger.debug("Request cancelled during shutdown")
+
+        return sse_middleware
 
     async def handle_root(self, request: Request) -> Response:
         """Handle root endpoint - return server information."""
@@ -366,21 +369,26 @@ class MCPHTTPServer:
 
         logger.info("New SSE connection established")
 
-        async with self.sse_transport.connect_sse(scope, receive, send) as (
-            read_stream,
-            write_stream,
-        ):
-            try:
-                await self.mcp_server.run(
-                    read_stream,
-                    write_stream,
-                    self.mcp_server.create_initialization_options(),
-                    raise_exceptions=False,
-                )
-            except Exception as e:
-                logger.exception(f"Error in SSE session: {e}")
-            finally:
-                logger.info("SSE connection closed")
+        try:
+            async with self.sse_transport.connect_sse(scope, receive, send) as (
+                read_stream,
+                write_stream,
+            ):
+                try:
+                    await self.mcp_server.run(
+                        read_stream,
+                        write_stream,
+                        self.mcp_server.create_initialization_options(),
+                        raise_exceptions=False,
+                    )
+                except Exception as e:
+                    logger.exception(f"Error in SSE session: {e}")
+                finally:
+                    logger.info("SSE connection closed")
+        except asyncio.CancelledError:
+            logger.info("SSE connection cancelled (shutdown)")
+        except Exception as e:
+            logger.debug(f"SSE connection terminated: {e}")
 
     async def handle_messages_endpoint(self, scope, receive, send):
         """
@@ -393,6 +401,8 @@ class MCPHTTPServer:
 
         try:
             await self.sse_transport.handle_post_message(scope, receive, send)
+        except asyncio.CancelledError:
+            logger.debug("Message handling cancelled (shutdown)")
         except Exception as e:
             logger.exception(f"Error handling SSE message: {e}")
             # Send error response

--- a/clang_index_mcp/_persistence/cache_manager.py
+++ b/clang_index_mcp/_persistence/cache_manager.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from .._core.error_tracking_adapter import ErrorTrackingAdapter
+from .error_tracking_adapter import ErrorTrackingAdapter
 from .._indexing.ports.cache_backend import CacheBackend
 from .._persistence.cache_validation_context import CacheValidationContext
 from .._persistence.project_identity import ProjectIdentity

--- a/clang_index_mcp/_persistence/error_tracking_adapter.py
+++ b/clang_index_mcp/_persistence/error_tracking_adapter.py
@@ -1,0 +1,53 @@
+"""Adapter implementing the cache recovery port with concrete error tracking."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from .._core.error_tracking import ErrorTracker
+from .recovery import RecoveryManager
+from .ports.recovery import CacheRecoveryPort
+
+
+class ErrorTrackingAdapter:
+    """Adapter that exposes ErrorTracker + RecoveryManager as CacheRecoveryPort."""
+
+    def __init__(
+        self,
+        error_tracker: Optional[ErrorTracker] = None,
+        recovery_manager: Optional[RecoveryManager] = None,
+    ):
+        self._error_tracker = error_tracker or ErrorTracker()
+        self._recovery_manager = recovery_manager or RecoveryManager()
+
+    def record_operation(self, operation: str) -> None:
+        self._error_tracker.record_operation(operation)
+
+    def record_error(
+        self,
+        error_type: str,
+        error_message: str,
+        operation: str,
+        recoverable: bool = True,
+    ) -> bool:
+        return self._error_tracker.record_error(error_type, error_message, operation, recoverable)
+
+    def get_error_summary(self) -> Dict[str, Any]:
+        return self._error_tracker.get_error_summary()
+
+    def reset(self) -> None:
+        self._error_tracker.reset()
+
+    def backup_database(
+        self, db_path: Union[str, Path], backup_suffix: str = ".backup"
+    ) -> Optional[str]:
+        return self._recovery_manager.backup_database(db_path, backup_suffix)
+
+    def attempt_repair(self, db_path: Union[str, Path]) -> bool:
+        return self._recovery_manager.attempt_repair(db_path)
+
+    def clear_cache(self, cache_dir: Union[str, Path]) -> bool:
+        return self._recovery_manager.clear_cache(cache_dir)
+
+
+# Re-export for typing convenience
+CacheRecoveryPort.register(ErrorTrackingAdapter)

--- a/clang_index_mcp/_search/call_graph_service.py
+++ b/clang_index_mcp/_search/call_graph_service.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Set
 from .._core import diagnostics
 from .._search.call_graph import CallGraphAnalyzer
 from .._search.dependency_graph import DependencyGraphBuilder
-from .._persistence.persistence_context import PersistenceContext
+from .._persistence.cache_manager import CacheManager
 from .._symbols.usr_decoder import usr_to_display_name
 from .._symbols.model import build_location_objects, omit_empty
 
@@ -22,16 +22,14 @@ class CallGraphService:
     and call path queries.
     """
 
-    def __init__(self, context: PersistenceContext):
+    def __init__(self, cache_manager: CacheManager):
         """
         Initialize CallGraphService.
 
         Args:
-            context: Persistence context for access to cache_manager.
+            cache_manager: Cache manager for persistent call site storage.
         """
-        self.context = context
-        assert context.cache_manager is not None
-        self.cache_manager = context.cache_manager
+        self.cache_manager = cache_manager
 
         # Dependencies set after construction to break the circular dependency
         # between CallGraphService and SymbolIndexStore/QueryEngine.

--- a/clang_index_mcp/_search/smart_fallback.py
+++ b/clang_index_mcp/_search/smart_fallback.py
@@ -62,13 +62,13 @@ _SIGNATURE_INDICATORS = [
 ]
 
 # Additional indicators: pattern has spaces + identifiers (looks like type + name)
-_PROTOTYPE_PATTERN = re.compile(r"^[a-zA-Z_][\w:]*\s+[a-zA-Z_][\w:]*\s*\(", re.ASCII)
+PROTOTYPE_PATTERN = re.compile(r"^[a-zA-Z_][\w:]*\s+[a-zA-Z_][\w:]*\s*\(", re.ASCII)
 
 # C++ identifier pattern
 _IDENTIFIER_RE = re.compile(r"[a-zA-Z_]\w*(?:::[a-zA-Z_]\w*)*")
 
 
-def _looks_like_signature(pattern: str) -> bool:
+def looks_like_signature(pattern: str) -> bool:
     """Check if pattern looks like a C++ function signature rather than a name."""
     # Must have at least one space (type + name) or parentheses
     if "(" in pattern:
@@ -317,7 +317,7 @@ class SmartFallback:
         function_index: Dict[str, List[Any]],
     ) -> Optional[FallbackResult]:
         """Detect signature/prototype used as pattern instead of symbol name."""
-        if not _looks_like_signature(pattern):
+        if not looks_like_signature(pattern):
             return None
 
         extracted = _extract_identifier_from_signature(pattern)

--- a/clang_index_mcp/composition_root.py
+++ b/clang_index_mcp/composition_root.py
@@ -89,8 +89,8 @@ class CompositionRoot:
 
         # Wire services in dependency order
 
-        # 1. CallGraphService (needs persistence context)
-        self.call_graph_service = CallGraphService(self.context.persistence)
+        # 1. CallGraphService (needs cache_manager for call site storage)
+        self.call_graph_service = CallGraphService(self.cache_manager)
         self.context.symbols.call_graph_service = self.call_graph_service
 
         # 2. SymbolIndexStore (needs concurrency and call graph)

--- a/clang_index_mcp/composition_root.py
+++ b/clang_index_mcp/composition_root.py
@@ -162,8 +162,10 @@ class CompositionRoot:
         self.cache_orchestrator.calculate_compile_commands_hash()
         self.cache_orchestrator.restore_or_reset_header_tracking()
 
-        # 6. ClangParser (needs persistence context)
-        self.clang_parser = ClangParser(self.context.persistence)
+        # 6. ClangParser (uses cache_manager for error logging)
+        self.clang_parser = ClangParser(
+            log_parse_error=self.cache_manager.log_parse_error,
+        )
         self.context.compilation.clang_parser = self.clang_parser
 
         # 7. SymbolExtractor

--- a/clang_index_mcp/project_context.py
+++ b/clang_index_mcp/project_context.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 from ._core.cancellation_coordinator import CancellationCoordinator
 from ._core.concurrency_context import ConcurrencyContext
-from ._core.error_tracking_adapter import ErrorTrackingAdapter
+from ._persistence.error_tracking_adapter import ErrorTrackingAdapter
 from ._contexts import ProjectIdentityContext
 from ._contexts.runtime_context import RuntimeContext
 from ._compilation.clang_parser import ClangParser

--- a/clang_index_mcp/project_context.py
+++ b/clang_index_mcp/project_context.py
@@ -203,3 +203,36 @@ class ProjectContext:
     def max_workers(self) -> int:
         """Convenience accessor for the worker pool size."""
         return self.runtime.execution.max_workers
+
+    def build_incremental_context(self):
+        """Build an IncrementalContext from the current project state.
+
+        Returns an IncrementalContext with all services needed by incremental
+        analysis modules, or None if required services are not yet initialized.
+        """
+        from ._contexts.incremental_context import IncrementalContext
+
+        compilation_env = self.compilation.compilation_env
+        symbol_store = self.symbols.symbol_store
+        cache_orchestrator = self.persistence.cache_orchestrator
+        call_graph_service = self.symbols.call_graph_service
+
+        if not all([compilation_env, symbol_store, cache_orchestrator, call_graph_service]):
+            return None
+
+        return IncrementalContext(
+            project_root=self.identity.project_root,
+            config=self.identity.config,
+            cache_manager=self.persistence.cache_manager,
+            cache_orchestrator=cache_orchestrator,
+            compilation_env=compilation_env,
+            symbol_store=symbol_store,
+            concurrency=self.runtime.concurrency,
+            call_graph_analyzer=call_graph_service.call_graph_analyzer,
+            dependency_graph=call_graph_service.dependency_graph,
+            config_file=(
+                str(self.identity.project_identity.config_file_path)
+                if self.identity.project_identity.config_file_path
+                else None
+            ),
+        )

--- a/tests/test_change_scanner.py
+++ b/tests/test_change_scanner.py
@@ -57,6 +57,26 @@ class TestChangeSet(unittest.TestCase):
         self.assertIn("1 modified", str_repr)
 
 
+def _make_mock_ctx(test_dir):
+    """Create a mock IncrementalContext with all required attributes."""
+    ctx = Mock()
+    ctx.project_root = test_dir
+    ctx.config = Mock()
+    ctx.config.get_compile_commands_config.return_value = CompileCommandsConfig(
+        compile_commands_path="compile_commands.json"
+    )
+    ctx.cache_manager = Mock()
+    ctx.cache_orchestrator = Mock()
+    ctx.cache_orchestrator.get_processed_headers = Mock(return_value={})
+    ctx.cache_orchestrator.compile_commands_hash = ""
+    ctx.compilation_env = Mock()
+    ctx.compilation_env.file_scanner = Mock()
+    ctx.symbol_store = Mock()
+    ctx.symbol_store.has_file_hash = Mock(return_value=False)
+    ctx.symbol_store.get_file_hash = Mock(return_value="")
+    return ctx
+
+
 class TestChangeScanner(unittest.TestCase):
     """Test cases for ChangeScanner class."""
 
@@ -64,25 +84,11 @@ class TestChangeScanner(unittest.TestCase):
         """Set up test fixtures."""
         self.test_dir = Path(tempfile.mkdtemp())
 
-        # Create mock analyzer
-        self.analyzer = Mock()
-        self.analyzer.project_root = self.test_dir
-        self.analyzer.config = Mock()
-        self.analyzer.cache_manager = Mock()
-        self.analyzer.context.file_scanner = Mock()
-        self.analyzer.context.cache_orchestrator.get_processed_headers = Mock(return_value={})
-        self.analyzer.context.cache_orchestrator.compile_commands_hash = ""
-        self.analyzer.context.symbol_store.file_hashes = {}  # FIX: Add file_hashes for fallback checking
-        self.analyzer.context.symbol_store.has_file_hash = Mock(return_value=False)
-        self.analyzer.context.symbol_store.get_file_hash = Mock(return_value="")
-
-        # Mock config
-        self.analyzer.config.get_compile_commands_config.return_value = CompileCommandsConfig(
-            compile_commands_path="compile_commands.json"
-        )
+        # Create mock context
+        self.ctx = _make_mock_ctx(self.test_dir)
 
         # Create scanner
-        self.scanner = ChangeScanner(self.analyzer)
+        self.scanner = ChangeScanner(self.ctx)
 
     def tearDown(self):
         """Clean up test fixtures."""
@@ -91,14 +97,14 @@ class TestChangeScanner(unittest.TestCase):
     def test_scan_empty_project(self):
         """Test scanning a project with no files."""
         # Mock empty file list
-        self.analyzer.context.file_scanner.find_cpp_files.return_value = []
-        self.analyzer.context.cache_orchestrator.get_processed_headers.return_value = {}
-        self.analyzer.cache_manager.backend.get_file_metadata.return_value = None
+        self.ctx.compilation_env.file_scanner.find_cpp_files.return_value = []
+        self.ctx.cache_orchestrator.get_processed_headers.return_value = {}
+        self.ctx.cache_manager.backend.get_file_metadata.return_value = None
 
         # Mock backend to return empty cached files
         backend_mock = Mock()
         backend_mock.get_all_cached_file_paths.return_value = set()
-        self.analyzer.cache_manager.backend = backend_mock
+        self.ctx.cache_manager.backend = backend_mock
 
         changes = self.scanner.scan_for_changes()
 
@@ -109,16 +115,16 @@ class TestChangeScanner(unittest.TestCase):
         new_file = str(self.test_dir / "new.cpp")
 
         # Mock file scanner to return new file
-        self.analyzer.context.file_scanner.find_cpp_files.return_value = [new_file]
+        self.ctx.compilation_env.file_scanner.find_cpp_files.return_value = [new_file]
 
         # Mock empty headers
-        self.analyzer.context.cache_orchestrator.get_processed_headers.return_value = {}
+        self.ctx.cache_orchestrator.get_processed_headers.return_value = {}
 
         # Create backend mock
         backend_mock = Mock()
         backend_mock.get_file_metadata = Mock(return_value=None)  # File not in cache
         backend_mock.get_all_cached_file_paths.return_value = set()
-        self.analyzer.cache_manager.backend = backend_mock
+        self.ctx.cache_manager.backend = backend_mock
 
         changes = self.scanner.scan_for_changes()
 
@@ -131,19 +137,19 @@ class TestChangeScanner(unittest.TestCase):
         modified_file = str(self.test_dir / "modified.cpp")
 
         # Mock file scanner
-        self.analyzer.context.file_scanner.find_cpp_files.return_value = [modified_file]
+        self.ctx.compilation_env.file_scanner.find_cpp_files.return_value = [modified_file]
 
         # Mock file hash to indicate change
-        self.analyzer.context.cache_orchestrator.get_file_hash.return_value = "new_hash"
+        self.ctx.cache_orchestrator.get_file_hash.return_value = "new_hash"
 
         # Mock empty headers
-        self.analyzer.context.cache_orchestrator.get_processed_headers.return_value = {}
+        self.ctx.cache_orchestrator.get_processed_headers.return_value = {}
 
         # Create backend mock with old hash
         backend_mock = Mock()
         backend_mock.get_file_metadata = Mock(return_value={"file_hash": "old_hash"})
         backend_mock.get_all_cached_file_paths.return_value = set()
-        self.analyzer.cache_manager.backend = backend_mock
+        self.ctx.cache_manager.backend = backend_mock
 
         changes = self.scanner.scan_for_changes()
 
@@ -159,18 +165,18 @@ class TestChangeScanner(unittest.TestCase):
         Path(header_file).write_text("#pragma once\n")
 
         # Mock file scanner (no source files)
-        self.analyzer.context.file_scanner.find_cpp_files.return_value = []
+        self.ctx.compilation_env.file_scanner.find_cpp_files.return_value = []
 
         # Mock header tracker with old hash
-        self.analyzer.context.cache_orchestrator.get_processed_headers.return_value = {header_file: "old_hash"}
+        self.ctx.cache_orchestrator.get_processed_headers.return_value = {header_file: "old_hash"}
 
         # Mock file hash to indicate change
-        self.analyzer.context.cache_orchestrator.get_file_hash.return_value = "new_hash"
+        self.ctx.cache_orchestrator.get_file_hash.return_value = "new_hash"
 
         # Mock empty cached files
         backend_mock = Mock()
         backend_mock.get_all_cached_file_paths.return_value = set()
-        self.analyzer.cache_manager.backend = backend_mock
+        self.ctx.cache_manager.backend = backend_mock
 
         changes = self.scanner.scan_for_changes()
 
@@ -183,15 +189,15 @@ class TestChangeScanner(unittest.TestCase):
         deleted_file = str(self.test_dir / "deleted.cpp")
 
         # Mock file scanner (no files)
-        self.analyzer.context.file_scanner.find_cpp_files.return_value = []
+        self.ctx.compilation_env.file_scanner.find_cpp_files.return_value = []
 
         # Mock cached files to include deleted file
         backend_mock = Mock()
         backend_mock.get_all_cached_file_paths.return_value = {deleted_file}
-        self.analyzer.cache_manager.backend = backend_mock
+        self.ctx.cache_manager.backend = backend_mock
 
         # Mock empty headers
-        self.analyzer.context.cache_orchestrator.get_processed_headers.return_value = {}
+        self.ctx.cache_orchestrator.get_processed_headers.return_value = {}
 
         changes = self.scanner.scan_for_changes()
 
@@ -205,17 +211,17 @@ class TestChangeScanner(unittest.TestCase):
         cc_file.write_text("[]")
 
         # Mock file scanner
-        self.analyzer.context.file_scanner.find_cpp_files.return_value = []
+        self.ctx.compilation_env.file_scanner.find_cpp_files.return_value = []
 
         # Mock compile_commands_hash to indicate change
-        self.analyzer.context.cache_orchestrator.compile_commands_hash = "old_hash"
-        self.analyzer.context.cache_orchestrator.get_file_hash.return_value = "new_hash"
+        self.ctx.cache_orchestrator.compile_commands_hash = "old_hash"
+        self.ctx.cache_orchestrator.get_file_hash.return_value = "new_hash"
 
         # Mock empty headers and cached files
-        self.analyzer.context.cache_orchestrator.get_processed_headers.return_value = {}
+        self.ctx.cache_orchestrator.get_processed_headers.return_value = {}
         backend_mock = Mock()
         backend_mock.get_all_cached_file_paths.return_value = set()
-        self.analyzer.cache_manager.backend = backend_mock
+        self.ctx.cache_manager.backend = backend_mock
 
         changes = self.scanner.scan_for_changes()
 
@@ -226,10 +232,10 @@ class TestChangeScanner(unittest.TestCase):
         file_path = str(self.test_dir / "unchanged.cpp")
 
         # Mock cache with matching hash
-        self.analyzer.cache_manager.backend.get_file_metadata.return_value = {
+        self.ctx.cache_manager.backend.get_file_metadata.return_value = {
             "file_hash": "same_hash"
         }
-        self.analyzer.context.cache_orchestrator.get_file_hash.return_value = "same_hash"
+        self.ctx.cache_orchestrator.get_file_hash.return_value = "same_hash"
 
         change_type = self.scanner._check_file_change(file_path)
 

--- a/tests/test_incremental_analyzer.py
+++ b/tests/test_incremental_analyzer.py
@@ -17,6 +17,46 @@ def _fake_process_file_worker(spec):
     return (spec.file_path, success, False, [], [], {})
 
 
+def _make_mock_ctx(test_dir):
+    """Create a mock IncrementalContext with all required attributes."""
+    ctx = Mock()
+    ctx.project_root = test_dir
+    ctx.config = Mock()
+    ctx.config.get_compile_commands_config.return_value = CompileCommandsConfig(
+        compile_commands_path="compile_commands.json"
+    )
+    ctx.config_file = None
+    ctx.cache_manager = Mock()
+    ctx.cache_orchestrator = Mock()
+    ctx.cache_orchestrator.invalidate_header = Mock()
+    ctx.cache_orchestrator.clear_header_tracker = Mock()
+    ctx.cache_orchestrator.mark_header_completed = Mock()
+    ctx.cache_orchestrator.remove_deleted_file = Mock()
+    ctx.cache_orchestrator.compile_commands_hash = ""
+    ctx.compilation_env = Mock()
+    ctx.compilation_env.file_scanner = Mock()
+    ctx.compilation_env.compile_commands_manager = Mock()
+    ctx.compilation_env.compile_commands_manager.compute_commands_diff = Mock(
+        return_value=(set(), set(), set())
+    )
+    ctx.compilation_env.compile_commands_manager.store_command_hashes = Mock(return_value=0)
+    ctx.compilation_env.compile_commands_manager.get_compile_commands_hash = Mock(
+        return_value=""
+    )
+    ctx.symbol_store = Mock()
+    ctx.concurrency = Mock()
+    ctx.call_graph_analyzer = Mock()
+    ctx.dependency_graph = Mock()
+
+    # Mock cache backend
+    backend_mock = Mock()
+    backend_mock.set_compile_args_hash = Mock(return_value=True)
+    backend_mock.remove_file_cache = Mock()
+    ctx.cache_manager.backend = backend_mock
+
+    return ctx
+
+
 class TestAnalysisResult(unittest.TestCase):
     """Test cases for AnalysisResult class."""
 
@@ -49,44 +89,15 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         """Set up test fixtures."""
         self.test_dir = Path(tempfile.mkdtemp())
 
-        # Create mock analyzer with all required components
-        self.analyzer = Mock()
-        self.analyzer.project_root = self.test_dir
-        self.analyzer.config = Mock()
-        self.analyzer.cache_manager = Mock()
-        self.analyzer.context.file_scanner = Mock()
-        self.analyzer.context.cache_orchestrator.invalidate_header = Mock()
-        self.analyzer.context.cache_orchestrator.clear_header_tracker = Mock()
-        self.analyzer.context.cache_orchestrator.mark_header_completed = Mock()
-        self.analyzer.context.cache_orchestrator.remove_deleted_file = Mock()
-        self.analyzer.context.call_graph_service.dependency_graph = Mock()
-        self.analyzer.context.compile_commands_manager = Mock()
-        self.analyzer.context.compile_commands_manager.compute_commands_diff = Mock(
-            return_value=(set(), set(), set())
-        )
-        self.analyzer.context.compile_commands_manager.store_command_hashes = Mock(return_value=0)
-        self.analyzer.context.compile_commands_manager.get_compile_commands_hash = Mock(
-            return_value=""
-        )
-        self.analyzer.context.cache_orchestrator.compile_commands_hash = ""
-
-        # Mock config
-        self.analyzer.config.get_compile_commands_config.return_value = CompileCommandsConfig(
-            compile_commands_path="compile_commands.json"
-        )
-
-        # Mock cache backend
-        backend_mock = Mock()
-        backend_mock.set_compile_args_hash = Mock(return_value=True)
-        backend_mock.remove_file_cache = Mock()
-        self.analyzer.cache_manager.backend = backend_mock
+        # Create mock context
+        self.ctx = _make_mock_ctx(self.test_dir)
 
         # Create incremental analyzer
-        self.incremental = IncrementalAnalyzer(self.analyzer)
+        self.incremental = IncrementalAnalyzer(self.ctx)
 
         # Patch process pool to use threads and worker to avoid pickling Mock objects.
         # This is a unit-testing seam: production always uses real ProcessPoolExecutor,
-        # but Mock analyzers cannot be pickled across processes.
+        # but Mock contexts cannot be pickled across processes.
         self._pool_patch = patch(
             "clang_index_mcp._incremental.worker_orchestrator.ProcessPoolExecutor",
             side_effect=lambda max_workers=None, mp_context=None: __import__(
@@ -144,7 +155,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         # Mock dependency graph to return dependents
         dependent1 = str(self.test_dir / "main.cpp")
         dependent2 = str(self.test_dir / "test.cpp")
-        self.analyzer.context.call_graph_service.dependency_graph.find_transitive_dependents.return_value = {
+        self.ctx.dependency_graph.find_transitive_dependents.return_value = {
             dependent1,
             dependent2,
         }
@@ -156,7 +167,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
 
             # Should re-analyze both dependents
             self.assertEqual(result.files_analyzed, 2)
-            self.analyzer.context.call_graph_service.dependency_graph.find_transitive_dependents.assert_called_once_with(
+            self.ctx.dependency_graph.find_transitive_dependents.assert_called_once_with(
                 header_file
             )
 
@@ -195,7 +206,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
 
             # Should remove file from cache and dependencies
             self.assertEqual(result.files_removed, 1)
-            self.analyzer.context.cache_orchestrator.remove_deleted_file.assert_called_once_with(
+            self.ctx.cache_orchestrator.remove_deleted_file.assert_called_once_with(
                 removed_file
             )
 
@@ -224,13 +235,13 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         mock_command_map.__iter__ = lambda x: iter(new_commands)
         mock_command_map.__getitem__ = lambda x, key: new_commands[key]
 
-        self.analyzer.context.compile_commands_manager.file_to_command_map = mock_command_map
-        self.analyzer.context.compile_commands_manager._load_compile_commands = Mock()
-        self.analyzer.context.compile_commands_manager.compute_commands_diff = Mock(
+        self.ctx.compilation_env.compile_commands_manager.file_to_command_map = mock_command_map
+        self.ctx.compilation_env.compile_commands_manager._load_compile_commands = Mock()
+        self.ctx.compilation_env.compile_commands_manager.compute_commands_diff = Mock(
             return_value=({file3}, {file2}, {file1})
         )
-        self.analyzer.context.compile_commands_manager.store_command_hashes = Mock()
-        self.analyzer.context.compile_commands_manager.get_compile_commands_hash = Mock(
+        self.ctx.compilation_env.compile_commands_manager.store_command_hashes = Mock()
+        self.ctx.compilation_env.compile_commands_manager.get_compile_commands_hash = Mock(
             return_value=""
         )
 
@@ -261,7 +272,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         # Mock dependency graph
         dependent1 = str(self.test_dir / "test1.cpp")
         dependent2 = str(self.test_dir / "test2.cpp")
-        self.analyzer.context.call_graph_service.dependency_graph.find_transitive_dependents.return_value = {
+        self.ctx.dependency_graph.find_transitive_dependents.return_value = {
             dependent1,
             dependent2,
         }
@@ -282,7 +293,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
     def test_handle_header_change_without_dependency_graph(self):
         """Test header change handling when no dependency graph available."""
         # Disable dependency graph
-        self.analyzer.context.call_graph_service.dependency_graph = None
+        self.ctx.dependency_graph = None
 
         changeset = ChangeSet()
         header_file = str(self.test_dir / "utils.h")
@@ -315,7 +326,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
     def test_remove_file_handles_exceptions(self):
         """Test _remove_file handles exceptions gracefully."""
         # Mock orchestrator cleanup to raise exception
-        self.analyzer.context.cache_orchestrator.remove_deleted_file.side_effect = Exception(
+        self.ctx.cache_orchestrator.remove_deleted_file.side_effect = Exception(
             "Test error"
         )
 
@@ -325,7 +336,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         self.incremental._remove_file(removed_file)
 
         # Verify the orchestrator was invoked
-        self.analyzer.context.cache_orchestrator.remove_deleted_file.assert_called_once_with(
+        self.ctx.cache_orchestrator.remove_deleted_file.assert_called_once_with(
             removed_file
         )
 
@@ -336,7 +347,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         changeset.modified_headers = {header_file}
 
         # Mock dependency graph to return empty set
-        self.analyzer.context.call_graph_service.dependency_graph.find_transitive_dependents.return_value = set()
+        self.ctx.dependency_graph.find_transitive_dependents.return_value = set()
 
         with patch.object(self.incremental.scanner, "scan_for_changes") as mock_scan:
             mock_scan.return_value = changeset
@@ -344,7 +355,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
             self.incremental.perform_incremental_analysis()
 
             # Verify header tracker was invalidated
-            self.analyzer.context.cache_orchestrator.invalidate_header.assert_called_once_with(header_file)
+            self.ctx.cache_orchestrator.invalidate_header.assert_called_once_with(header_file)
 
     def test_compile_commands_hash_updated(self):
         """Test compile_commands_hash is updated after change."""
@@ -356,12 +367,12 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         cc_file.write_text("[]")
 
         # Mock empty commands
-        self.analyzer.context.compile_commands_manager.file_to_command_map = {}
-        self.analyzer.context.compile_commands_manager.compute_commands_diff = Mock(
+        self.ctx.compilation_env.compile_commands_manager.file_to_command_map = {}
+        self.ctx.compilation_env.compile_commands_manager.compute_commands_diff = Mock(
             return_value=(set(), set(), set())
         )
-        self.analyzer.context.compile_commands_manager.store_command_hashes = Mock()
-        self.analyzer.context.compile_commands_manager.get_compile_commands_hash = Mock(
+        self.ctx.compilation_env.compile_commands_manager.store_command_hashes = Mock()
+        self.ctx.compilation_env.compile_commands_manager.get_compile_commands_hash = Mock(
             return_value="new_hash"
         )
 
@@ -371,7 +382,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
             self.incremental.perform_incremental_analysis()
 
             # Verify hash was updated
-            self.assertEqual(self.analyzer.context.cache_orchestrator.compile_commands_hash, "new_hash")
+            self.assertEqual(self.ctx.cache_orchestrator.compile_commands_hash, "new_hash")
 
 
 if __name__ == "__main__":

--- a/tests/test_incremental_analyzer.py
+++ b/tests/test_incremental_analyzer.py
@@ -100,7 +100,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
         # but Mock contexts cannot be pickled across processes.
         self._pool_patch = patch(
             "clang_index_mcp._incremental.worker_orchestrator.ProcessPoolExecutor",
-            side_effect=lambda max_workers=None, mp_context=None: __import__(
+            side_effect=lambda max_workers=None, mp_context=None, initializer=None: __import__(
                 "concurrent.futures", fromlist=["ThreadPoolExecutor"]
             ).ThreadPoolExecutor(max_workers=max_workers or 2),
         )

--- a/tests/test_incremental_integration.py
+++ b/tests/test_incremental_integration.py
@@ -122,7 +122,10 @@ int multiply(int a, int b) {
         analyzer.index_project()
 
         # Create incremental analyzer
-        incremental = IncrementalAnalyzer(analyzer)
+        incremental = IncrementalAnalyzer(
+            analyzer.context.build_incremental_context(),
+            is_interrupted=analyzer._is_interrupted,
+        )
 
         # Run incremental analysis - should detect no changes
         result = incremental.perform_incremental_analysis()
@@ -150,7 +153,10 @@ int multiply(int a, int b) {
 """)
 
         # Create incremental analyzer
-        incremental = IncrementalAnalyzer(analyzer)
+        incremental = IncrementalAnalyzer(
+            analyzer.context.build_incremental_context(),
+            is_interrupted=analyzer._is_interrupted,
+        )
 
         # Run incremental analysis
         result = incremental.perform_incremental_analysis()
@@ -192,7 +198,10 @@ int subtract(int a, int b) {  // New function
 """)
 
         # Create incremental analyzer
-        incremental = IncrementalAnalyzer(analyzer)
+        incremental = IncrementalAnalyzer(
+            analyzer.context.build_incremental_context(),
+            is_interrupted=analyzer._is_interrupted,
+        )
 
         # Run incremental analysis
         result = incremental.perform_incremental_analysis()
@@ -233,7 +242,10 @@ int divide(int a, int b) {
         analyzer.context.compile_commands_manager._load_compile_commands()
 
         # Create incremental analyzer
-        incremental = IncrementalAnalyzer(analyzer)
+        incremental = IncrementalAnalyzer(
+            analyzer.context.build_incremental_context(),
+            is_interrupted=analyzer._is_interrupted,
+        )
 
         # Run incremental analysis
         result = incremental.perform_incremental_analysis()
@@ -264,7 +276,10 @@ int divide(int a, int b) {
         self.utils_cpp.unlink()
 
         # Create incremental analyzer
-        incremental = IncrementalAnalyzer(analyzer)
+        incremental = IncrementalAnalyzer(
+            analyzer.context.build_incremental_context(),
+            is_interrupted=analyzer._is_interrupted,
+        )
 
         # Run incremental analysis
         result = incremental.perform_incremental_analysis()
@@ -298,7 +313,10 @@ int divide(int a, int b) {
         self.cc_file.write_text(json.dumps(cc_data, indent=2))
 
         # Create incremental analyzer
-        incremental = IncrementalAnalyzer(analyzer)
+        incremental = IncrementalAnalyzer(
+            analyzer.context.build_incremental_context(),
+            is_interrupted=analyzer._is_interrupted,
+        )
 
         # Run incremental analysis
         result = incremental.perform_incremental_analysis()

--- a/tests/test_smart_fallback.py
+++ b/tests/test_smart_fallback.py
@@ -15,7 +15,7 @@ from clang_index_mcp._search.smart_fallback import (
     _has_double_escapes,
     _has_unnecessary_anchors,
     _looks_like_short_regex,
-    _looks_like_signature,
+    looks_like_signature,
     _strip_anchors,
 )
 
@@ -55,39 +55,39 @@ def _make_index(*entries):
 
 class TestLooksLikeSignature:
     def test_function_with_parens(self):
-        assert _looks_like_signature("processData(int x)")
+        assert looks_like_signature("processData(int x)")
 
     def test_void_return_type(self):
-        assert _looks_like_signature("void processData")
+        assert looks_like_signature("void processData")
 
     def test_bool_return_type(self):
-        assert _looks_like_signature("bool isValid")
+        assert looks_like_signature("bool isValid")
 
     def test_const_reference(self):
-        assert _looks_like_signature("const IConfig &")
+        assert looks_like_signature("const IConfig &")
 
     def test_type_pointer(self):
-        assert _looks_like_signature("int* getData")
+        assert looks_like_signature("int* getData")
 
     def test_simple_name(self):
-        assert not _looks_like_signature("processData")
+        assert not looks_like_signature("processData")
 
     def test_qualified_name(self):
-        assert not _looks_like_signature("app::Handler::process")
+        assert not looks_like_signature("app::Handler::process")
 
     def test_regex_pattern(self):
-        assert not _looks_like_signature(".*Reporter")
+        assert not looks_like_signature(".*Reporter")
 
     def test_empty(self):
-        assert not _looks_like_signature("")
+        assert not looks_like_signature("")
 
     def test_single_keyword_no_space(self):
         """Single keyword without space is not a signature."""
-        assert not _looks_like_signature("void")
+        assert not looks_like_signature("void")
 
     def test_parens_only(self):
         """Just parentheses is a signature indicator."""
-        assert _looks_like_signature("()")
+        assert looks_like_signature("()")
 
 
 class TestExtractIdentifier:


### PR DESCRIPTION
## Summary

Fixes 5 Clean Architecture violations found in `clang_index_mcp/`. Each fix is a separate commit with full test validation.

### Changes

| Commit | Violation | Fix |
|--------|-----------|-----|
| `a3dd73d` | `_core/` imports from `_persistence/` | Moved `error_tracking_adapter` to `_persistence/`, re-export shim in old location |
| `989d252` | `_incremental/` depends on `CppAnalyzer` facade | Created `IncrementalContext` dataclass; all incremental modules accept it instead |
| `66ecd6b` | `_compilation/clang_parser` depends on `_persistence/` | `ClangParser` accepts `log_parse_error` callback instead of `PersistenceContext` |
| `159abf2` | `_search/call_graph_service` depends on `_persistence/` | `CallGraphService` accepts `CacheManager` directly instead of `PersistenceContext` |
| `eb8b6c5` | `_mcp/` imports `_search/` private internals | Made `PROTOTYPE_PATTERN` and `looks_like_signature` public |

### Validation

- All 1433 tests pass on every commit
- `make check` (format + lint + type-check) clean on every commit
- No performance regressions

### Remaining debt (not in scope)

- `project_context.py` God Object — backward-compat facade properties still present
- `_indexing/worker_pool.py` lazy `CppAnalyzer` import — inherent to process-pool worker design
- `_mcp/` importing `cpp_analyzer` — acceptable for outermost layer