### PR TITLE
refactor: replace Any with typed records in symbol parser pipeline

### DIFF
--- a/clang_index_mcp/_compilation/clang_parser.py
+++ b/clang_index_mcp/_compilation/clang_parser.py
@@ -1,7 +1,7 @@
 import threading
 from typing import Any, Callable, List, Optional, Tuple
 
-from clang.cindex import Index, TranslationUnit, TranslationUnitLoadError
+from clang.cindex import Index, TranslationUnit, TranslationUnitLoadError, Diagnostic
 
 from .._core import diagnostics
 
@@ -35,7 +35,7 @@ class ClangParser:
 
     def try_parse_with_fallback(
         self, file_path: str, args: List[str]
-    ) -> Tuple[Optional[Any], Optional[str]]:
+    ) -> Tuple[Optional[TranslationUnit], Optional[str]]:
         """Try parsing with progressive fallback if initial attempt fails."""
         index = self._get_thread_index()
         parse_options_attempts = [
@@ -65,7 +65,7 @@ class ClangParser:
         return None, error_msg
 
     @staticmethod
-    def _is_system_header_diagnostic(diag: Any) -> bool:
+    def _is_system_header_diagnostic(diag: Diagnostic) -> bool:
         """Check if a diagnostic originates from a system header."""
         if not diag.location.file:
             return False
@@ -85,7 +85,9 @@ class ClangParser:
 
         return any(pattern in file_path for pattern in system_patterns)
 
-    def _extract_diagnostics(self, tu: Any) -> Tuple[List[Any], List[Any]]:
+    def _extract_diagnostics(
+        self, tu: TranslationUnit
+    ) -> Tuple[List[Diagnostic], List[Diagnostic]]:
         """Extract error and warning diagnostics from translation unit."""
         error_diagnostics = []
         warning_diagnostics = []
@@ -108,7 +110,7 @@ class ClangParser:
         return error_diagnostics, warning_diagnostics
 
     @staticmethod
-    def _format_diagnostics(diagnostics_list: List[Any], max_count: int = 5) -> str:
+    def _format_diagnostics(diagnostics_list: List[Diagnostic], max_count: int = 5) -> str:
         """Format libclang diagnostics into a readable string."""
         if not diagnostics_list:
             return ""
@@ -134,7 +136,12 @@ class ClangParser:
         return "\n".join(messages)
 
     def handle_index_file_diagnostics(
-        self, file_path: str, tu: Any, current_hash: str, compile_args_hash: str, retry_count: int
+        self,
+        file_path: str,
+        tu: TranslationUnit,
+        current_hash: str,
+        compile_args_hash: str,
+        retry_count: int,
     ) -> Optional[str]:
         """Extract and process diagnostics. Returns error message if any."""
         error_diagnostics, warning_diagnostics = self._extract_diagnostics(tu)

--- a/clang_index_mcp/_compilation/clang_symbol_parser.py
+++ b/clang_index_mcp/_compilation/clang_symbol_parser.py
@@ -2,13 +2,14 @@
 
 import json
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
-from clang.cindex import CursorKind
+from clang.cindex import Cursor, CursorKind, TranslationUnit, Type
 
 from .._core import diagnostics
 from .._symbols.model import SymbolInfo
-from .._symbols.ports.parser import ParseResult, SymbolParser
+from .._symbols.ports.parser import CallSiteRecord, ParseResult, SymbolParser, TypeAliasRecord
 from .._symbols.alias_extractor import extract_alias_info
 from .._symbols.cursor_utils import extract_namespace, get_qualified_name
 from .._symbols.documentation_extractor import extract_documentation
@@ -20,6 +21,31 @@ if TYPE_CHECKING:
     from .._compilation.compilation_environment import CompilationEnvironment
     from .._persistence.cache_orchestrator import CacheOrchestrator
     from .._symbols.symbol_index_store import SymbolIndexStore
+
+
+@dataclass
+class LineRangeInfo:
+    """Line range and location information extracted from a cursor."""
+
+    file: str
+    line: int
+    column: int
+    start_line: int
+    end_line: int
+    header_file: Optional[str] = None
+    header_line: Optional[int] = None
+    header_start_line: Optional[int] = None
+    header_end_line: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CommonSymbolData:
+    """Common metadata extracted for any symbol during AST traversal."""
+
+    qualified_name: str
+    namespace: str
+    loc_info: LineRangeInfo
+    doc_info: Dict[str, Optional[str]]
 
 
 class ClangSymbolParser(SymbolParser):
@@ -46,8 +72,8 @@ class ClangSymbolParser(SymbolParser):
         # Buffers are normally reset by parse(); they are also kept available so
         # _process_cursor can be exercised directly in tests and diagnostics.
         self._symbols_buffer: List[SymbolInfo] = []
-        self._calls_buffer: List[Any] = []
-        self._aliases_buffer: List[Dict[str, Any]] = []
+        self._calls_buffer: List[CallSiteRecord] = []
+        self._aliases_buffer: List[TypeAliasRecord] = []
 
     def _is_project_file(self, file_path: str) -> bool:
         return self.compilation_env.is_project_file(file_path)
@@ -60,10 +86,10 @@ class ClangSymbolParser(SymbolParser):
         return self.symbol_store.index_lock
 
     @property
-    def class_index(self):
+    def class_index(self) -> Dict[str, List[SymbolInfo]]:
         return self.symbol_store.class_index
 
-    def _build_type_param_map(self, cursor: Any) -> Dict[str, str]:
+    def _build_type_param_map(self, cursor: Cursor) -> Dict[str, str]:
         """Build a map from 'type-parameter-D-I' to actual template parameter names."""
         type_param_map: Dict[str, str] = {}
         param_index = 0
@@ -78,7 +104,7 @@ class ClangSymbolParser(SymbolParser):
                 param_index += 1
         return type_param_map
 
-    def _resolve_base_name(self, base_type: Any, type_param_map: Dict[str, str]) -> str:
+    def _resolve_base_name(self, base_type: Type, type_param_map: Dict[str, str]) -> str:
         """Resolve the qualified name of a base type, substituting template parameters."""
         canonical_type = base_type.get_canonical()
         base_name_qualified = canonical_type.spelling
@@ -103,7 +129,7 @@ class ClangSymbolParser(SymbolParser):
 
         return str(base_name_qualified)
 
-    def _get_base_classes(self, cursor: Any) -> List[str]:
+    def _get_base_classes(self, cursor: Cursor) -> List[str]:
         """Extract base class names from a class cursor."""
         type_param_map = self._build_type_param_map(cursor)
 
@@ -114,7 +140,7 @@ class ClangSymbolParser(SymbolParser):
 
         return base_classes
 
-    def _find_primary_template_info(self, primary_template_usr: str) -> Optional[Any]:
+    def _find_primary_template_info(self, primary_template_usr: str) -> Optional[SymbolInfo]:
         """Look up the primary template in class_index by USR."""
         with self.index_lock:
             for name, infos in self.class_index.items():
@@ -123,7 +149,7 @@ class ClangSymbolParser(SymbolParser):
                         return info
         return None
 
-    def _parse_template_params(self, primary_info: Any) -> List[dict]:
+    def _parse_template_params(self, primary_info: SymbolInfo) -> List[dict]:
         """Parse template_parameters JSON from a primary template info."""
         if not primary_info.template_parameters:
             return []
@@ -134,7 +160,7 @@ class ClangSymbolParser(SymbolParser):
             return []
 
     def _resolve_instantiation_base_classes(
-        self, cursor: Any, primary_template_usr: Optional[str]
+        self, cursor: Cursor, primary_template_usr: Optional[str]
     ) -> List[str]:
         """Resolve base classes for explicit template instantiations."""
         if not primary_template_usr:
@@ -159,7 +185,7 @@ class ClangSymbolParser(SymbolParser):
         )
 
     @staticmethod
-    def _get_primary_file(cursor: Any) -> str:
+    def _get_primary_file(cursor: Cursor) -> str:
         """Determine the primary file path for a cursor using extent or location."""
         if cursor.extent and cursor.extent.start.file:
             return str(cursor.extent.start.file.name)
@@ -168,7 +194,7 @@ class ClangSymbolParser(SymbolParser):
         return ""
 
     @staticmethod
-    def _extract_cursor_extent(cursor: Any, location: Any) -> Tuple[int, int]:
+    def _extract_cursor_extent(cursor: Cursor, location: Any) -> Tuple[int, int]:
         """Extract start and end lines from a cursor's extent, falling back to location line."""
         try:
             extent = cursor.extent
@@ -179,7 +205,7 @@ class ClangSymbolParser(SymbolParser):
         return location.line, location.line
 
     @staticmethod
-    def _extract_definition_location(cursor: Any, result: dict) -> None:
+    def _extract_definition_location(cursor: Cursor, result: LineRangeInfo) -> None:
         """Populate header_* fields when declaration and definition are in different files."""
         try:
             definition_cursor = cursor.get_definition()
@@ -198,46 +224,42 @@ class ClangSymbolParser(SymbolParser):
             if decl_file == def_file:
                 return
 
-            result["header_file"] = def_file
-            result["header_line"] = def_location.line
+            result.header_file = def_file
+            result.header_line = def_location.line
 
             try:
                 def_extent = definition_cursor.extent
                 if def_extent and def_extent.start.file:
-                    result["header_start_line"] = def_extent.start.line
-                    result["header_end_line"] = def_extent.end.line
+                    result.header_start_line = def_extent.start.line
+                    result.header_end_line = def_extent.end.line
             except Exception:
-                result["header_start_line"] = def_location.line
-                result["header_end_line"] = def_location.line
+                result.header_start_line = def_location.line
+                result.header_end_line = def_location.line
 
         except Exception as e:
             diagnostics.debug(f"Could not track declaration/definition for {cursor.spelling}: {e}")
 
     @staticmethod
-    def _extract_line_range_info(cursor: Any) -> dict:
+    def _extract_line_range_info(cursor: Cursor) -> LineRangeInfo:
         """Extract line range and location information from a cursor."""
         location = cursor.location
         primary_file = ClangSymbolParser._get_primary_file(cursor)
         start_line, end_line = ClangSymbolParser._extract_cursor_extent(cursor, location)
 
-        result = {
-            "file": primary_file,
-            "line": location.line,
-            "column": location.column,
-            "start_line": start_line,
-            "end_line": end_line,
-            "header_file": None,
-            "header_line": None,
-            "header_start_line": None,
-            "header_end_line": None,
-        }
+        result = LineRangeInfo(
+            file=primary_file,
+            line=location.line,
+            column=location.column,
+            start_line=start_line,
+            end_line=end_line,
+        )
 
         ClangSymbolParser._extract_definition_location(cursor, result)
 
         return result
 
     @staticmethod
-    def _extract_template_parameters(cursor: Any) -> Optional[str]:
+    def _extract_template_parameters(cursor: Cursor) -> Optional[str]:
         """Extract template parameters from a template cursor."""
         template_params = []
 
@@ -256,7 +278,7 @@ class ClangSymbolParser(SymbolParser):
         return None
 
     @staticmethod
-    def _get_primary_template_usr(cursor: Any) -> Optional[str]:
+    def _get_primary_template_usr(cursor: Cursor) -> Optional[str]:
         """Get the USR of the primary template for a template specialization."""
         from clang import cindex
 
@@ -271,7 +293,7 @@ class ClangSymbolParser(SymbolParser):
 
         return None
 
-    def _detect_template_specialization(self, cursor: Any) -> bool:
+    def _detect_template_specialization(self, cursor: Cursor) -> bool:
         """Detect if cursor represents a template specialization."""
         try:
             kind = cursor.kind
@@ -302,19 +324,19 @@ class ClangSymbolParser(SymbolParser):
 
         return False
 
-    def _get_common_symbol_data(self, cursor: Any) -> Dict[str, Any]:
+    def _get_common_symbol_data(self, cursor: Cursor) -> CommonSymbolData:
         """Extract common metadata for any symbol."""
         qualified_name = get_qualified_name(cursor)
-        return {
-            "qualified_name": qualified_name,
-            "namespace": extract_namespace(qualified_name),
-            "loc_info": self._extract_line_range_info(cursor),
-            "doc_info": extract_documentation(cursor),
-        }
+        return CommonSymbolData(
+            qualified_name=qualified_name,
+            namespace=extract_namespace(qualified_name),
+            loc_info=self._extract_line_range_info(cursor),
+            doc_info=extract_documentation(cursor),
+        )
 
     def _process_cursor(
         self,
-        cursor: Any,
+        cursor: Cursor,
         should_extract_from_file: Optional[Callable[[str], bool]] = None,
         parent_class: str = "",
         parent_function_usr: str = "",
@@ -383,7 +405,7 @@ class ClangSymbolParser(SymbolParser):
 
     def _handle_class_template_cursor(
         self,
-        cursor: Any,
+        cursor: Cursor,
         should_extract: bool,
         should_extract_from_file: Optional[Callable[[str], bool]],
         parent_class: str,
@@ -395,10 +417,10 @@ class ClangSymbolParser(SymbolParser):
 
         if cursor.spelling and should_extract:
             common = self._get_common_symbol_data(cursor)
-            qualified_name = common["qualified_name"]
-            namespace = common["namespace"]
-            loc_info = common["loc_info"]
-            doc_info = common["doc_info"]
+            qualified_name = common.qualified_name
+            namespace = common.namespace
+            loc_info = common.loc_info
+            doc_info = common.doc_info
 
             base_classes = self._get_base_classes(cursor)
             template_params = self._extract_template_parameters(cursor)
@@ -413,11 +435,11 @@ class ClangSymbolParser(SymbolParser):
             info = SymbolInfo(
                 name=cursor.spelling,
                 kind=symbol_kind,
-                file=loc_info["file"],
-                line=loc_info["line"],
-                column=loc_info["column"],
+                file=loc_info.file,
+                line=loc_info.line,
+                column=loc_info.column,
                 qualified_name=qualified_name,
-                is_project=(self._is_project_file(loc_info["file"]) if loc_info["file"] else False),
+                is_project=(self._is_project_file(loc_info.file) if loc_info.file else False),
                 namespace=namespace,
                 parent_class="",
                 base_classes=base_classes,
@@ -426,12 +448,12 @@ class ClangSymbolParser(SymbolParser):
                 template_kind=symbol_kind,
                 template_parameters=template_params,
                 primary_template_usr=primary_usr,
-                start_line=loc_info["start_line"],
-                end_line=loc_info["end_line"],
-                header_file=loc_info["header_file"],
-                header_line=loc_info["header_line"],
-                header_start_line=loc_info["header_start_line"],
-                header_end_line=loc_info["header_end_line"],
+                start_line=loc_info.start_line,
+                end_line=loc_info.end_line,
+                header_file=loc_info.header_file,
+                header_line=loc_info.header_line,
+                header_start_line=loc_info.header_start_line,
+                header_end_line=loc_info.header_end_line,
                 is_definition=cursor.is_definition(),
                 brief=doc_info["brief"],
                 doc_comment=doc_info["doc_comment"],
@@ -448,7 +470,7 @@ class ClangSymbolParser(SymbolParser):
 
     def _handle_class_cursor(
         self,
-        cursor: Any,
+        cursor: Cursor,
         should_extract: bool,
         should_extract_from_file: Optional[Callable[[str], bool]],
         parent_class: str,
@@ -460,10 +482,10 @@ class ClangSymbolParser(SymbolParser):
 
         if cursor.spelling and should_extract:
             common = self._get_common_symbol_data(cursor)
-            qualified_name = common["qualified_name"]
-            namespace = common["namespace"]
-            loc_info = common["loc_info"]
-            doc_info = common["doc_info"]
+            qualified_name = common.qualified_name
+            namespace = common.namespace
+            loc_info = common.loc_info
+            doc_info = common.doc_info
 
             base_classes = self._get_base_classes(cursor)
             is_class_template_spec = self._detect_template_specialization(cursor)
@@ -482,11 +504,11 @@ class ClangSymbolParser(SymbolParser):
             info = SymbolInfo(
                 name=cursor.spelling,
                 kind="class" if kind == CursorKind.CLASS_DECL else "struct",
-                file=loc_info["file"],
-                line=loc_info["line"],
-                column=loc_info["column"],
+                file=loc_info.file,
+                line=loc_info.line,
+                column=loc_info.column,
                 qualified_name=qualified_name,
-                is_project=(self._is_project_file(loc_info["file"]) if loc_info["file"] else False),
+                is_project=(self._is_project_file(loc_info.file) if loc_info.file else False),
                 namespace=namespace,
                 parent_class="",
                 base_classes=base_classes,
@@ -496,12 +518,12 @@ class ClangSymbolParser(SymbolParser):
                 template_kind="full_specialization" if is_class_template_spec else None,
                 primary_template_usr=primary_usr,
                 template_arguments=stored_template_args,
-                start_line=loc_info["start_line"],
-                end_line=loc_info["end_line"],
-                header_file=loc_info["header_file"],
-                header_line=loc_info["header_line"],
-                header_start_line=loc_info["header_start_line"],
-                header_end_line=loc_info["header_end_line"],
+                start_line=loc_info.start_line,
+                end_line=loc_info.end_line,
+                header_file=loc_info.header_file,
+                header_line=loc_info.header_line,
+                header_start_line=loc_info.header_start_line,
+                header_end_line=loc_info.header_end_line,
                 is_definition=cursor.is_definition(),
                 brief=doc_info["brief"],
                 doc_comment=doc_info["doc_comment"],
@@ -518,7 +540,7 @@ class ClangSymbolParser(SymbolParser):
 
     def _handle_function_template_cursor(
         self,
-        cursor: Any,
+        cursor: Cursor,
         should_extract: bool,
         should_extract_from_file: Optional[Callable[[str], bool]],
         parent_class: str,
@@ -528,10 +550,10 @@ class ClangSymbolParser(SymbolParser):
         symbols_buffer = self._symbols_buffer
         if cursor.spelling and should_extract:
             common = self._get_common_symbol_data(cursor)
-            qualified_name = common["qualified_name"]
-            namespace = common["namespace"]
-            loc_info = common["loc_info"]
-            doc_info = common["doc_info"]
+            qualified_name = common.qualified_name
+            namespace = common.namespace
+            loc_info = common.loc_info
+            doc_info = common.doc_info
 
             signature = build_human_readable_signature(cursor)
             function_usr = cursor.get_usr() if cursor.get_usr() else ""
@@ -560,12 +582,12 @@ class ClangSymbolParser(SymbolParser):
             info = SymbolInfo(
                 name=cursor.spelling,
                 kind="function_template",
-                file=loc_info["file"],
-                line=loc_info["line"],
-                column=loc_info["column"],
+                file=loc_info.file,
+                line=loc_info.line,
+                column=loc_info.column,
                 qualified_name=qualified_name,
                 signature=signature,
-                is_project=(self._is_project_file(loc_info["file"]) if loc_info["file"] else False),
+                is_project=(self._is_project_file(loc_info.file) if loc_info.file else False),
                 namespace=namespace,
                 access=access,
                 parent_class=effective_parent_class,
@@ -574,12 +596,12 @@ class ClangSymbolParser(SymbolParser):
                 is_template=True,
                 template_kind="function_template",
                 template_parameters=template_params,
-                start_line=loc_info["start_line"],
-                end_line=loc_info["end_line"],
-                header_file=loc_info["header_file"],
-                header_line=loc_info["header_line"],
-                header_start_line=loc_info["header_start_line"],
-                header_end_line=loc_info["header_end_line"],
+                start_line=loc_info.start_line,
+                end_line=loc_info.end_line,
+                header_file=loc_info.header_file,
+                header_line=loc_info.header_line,
+                header_start_line=loc_info.header_start_line,
+                header_end_line=loc_info.header_end_line,
                 is_virtual=is_virtual,
                 is_pure_virtual=is_pure_virtual,
                 is_const=is_const,
@@ -600,7 +622,7 @@ class ClangSymbolParser(SymbolParser):
 
     def _handle_function_cursor(
         self,
-        cursor: Any,
+        cursor: Cursor,
         should_extract: bool,
         should_extract_from_file: Optional[Callable[[str], bool]],
         parent_class: str,
@@ -611,10 +633,10 @@ class ClangSymbolParser(SymbolParser):
         kind = cursor.kind
         if cursor.spelling and should_extract:
             common = self._get_common_symbol_data(cursor)
-            qualified_name = common["qualified_name"]
-            namespace = common["namespace"]
-            loc_info = common["loc_info"]
-            doc_info = common["doc_info"]
+            qualified_name = common.qualified_name
+            namespace = common.namespace
+            loc_info = common.loc_info
+            doc_info = common.doc_info
 
             signature = build_human_readable_signature(cursor)
             function_usr = cursor.get_usr() if cursor.get_usr() else ""
@@ -649,12 +671,12 @@ class ClangSymbolParser(SymbolParser):
             info = SymbolInfo(
                 name=cursor.spelling,
                 kind="function" if kind == CursorKind.FUNCTION_DECL else "method",
-                file=loc_info["file"],
-                line=loc_info["line"],
-                column=loc_info["column"],
+                file=loc_info.file,
+                line=loc_info.line,
+                column=loc_info.column,
                 qualified_name=qualified_name,
                 signature=signature,
-                is_project=(self._is_project_file(loc_info["file"]) if loc_info["file"] else False),
+                is_project=(self._is_project_file(loc_info.file) if loc_info.file else False),
                 namespace=namespace,
                 access=access,
                 parent_class=effective_parent_class if is_method else "",
@@ -663,12 +685,12 @@ class ClangSymbolParser(SymbolParser):
                 is_template=is_template_spec,
                 template_kind="full_specialization" if is_template_spec else None,
                 primary_template_usr=primary_usr,
-                start_line=loc_info["start_line"],
-                end_line=loc_info["end_line"],
-                header_file=loc_info["header_file"],
-                header_line=loc_info["header_line"],
-                header_start_line=loc_info["header_start_line"],
-                header_end_line=loc_info["header_end_line"],
+                start_line=loc_info.start_line,
+                end_line=loc_info.end_line,
+                header_file=loc_info.header_file,
+                header_line=loc_info.header_line,
+                header_start_line=loc_info.header_start_line,
+                header_end_line=loc_info.header_end_line,
                 is_virtual=is_virtual,
                 is_pure_virtual=is_pure_virtual,
                 is_const=is_const,
@@ -689,7 +711,7 @@ class ClangSymbolParser(SymbolParser):
 
     def _handle_type_alias_cursor(
         self,
-        cursor: Any,
+        cursor: Cursor,
         should_extract: bool,
         should_extract_from_file: Optional[Callable[[str], bool]],
         parent_class: str,
@@ -716,7 +738,7 @@ class ClangSymbolParser(SymbolParser):
                 )
 
     def _extract_template_call_info(
-        self, referenced: Any, called_usr: str
+        self, referenced: Cursor, called_usr: str
     ) -> Tuple[Optional[str], Optional[str]]:
         """Extract display_name and project-type template args from a template call."""
         try:
@@ -746,7 +768,7 @@ class ClangSymbolParser(SymbolParser):
         except Exception:
             return (None, None)
 
-    def _handle_call_cursor(self, cursor: Any, parent_function_usr: str) -> None:
+    def _handle_call_cursor(self, cursor: Cursor, parent_function_usr: str) -> None:
         """Process function calls within function bodies."""
         calls_buffer = self._calls_buffer
         referenced = cursor.referenced
@@ -784,20 +806,20 @@ class ClangSymbolParser(SymbolParser):
 
             location = cursor.location
             calls_buffer.append(
-                (
-                    parent_function_usr,
-                    called_usr,
-                    location.file.name if location.file else None,
-                    location.line if location.line else None,
-                    location.column if location.column else None,
-                    display_name,
-                    template_project_types,
+                CallSiteRecord(
+                    caller_usr=parent_function_usr,
+                    callee_usr=called_usr,
+                    file=location.file.name if location.file else None,
+                    line=location.line if location.line else None,
+                    column=location.column if location.column else None,
+                    display_name=display_name,
+                    template_project_types=template_project_types,
                 )
             )
 
     def parse(
         self,
-        tu: Any,
+        tu: TranslationUnit,
         source_file: str,
         should_extract_from_file: Optional[Callable[[str], bool]] = None,
     ) -> ParseResult:

--- a/clang_index_mcp/_compilation/compile_commands_diff.py
+++ b/clang_index_mcp/_compilation/compile_commands_diff.py
@@ -15,6 +15,11 @@ except ImportError:
     import diagnostics  # type: ignore[no-redef]
     from file_utils import hash_compile_args  # type: ignore[no-redef]
 
+try:
+    from .._indexing.ports.cache_backend import CacheBackend
+except ImportError:
+    CacheBackend = Any  # type: ignore[misc,assignment]
+
 
 def compute_commands_diff(
     old_commands: Dict[str, List[str]], new_commands: Dict[str, List[str]]
@@ -45,7 +50,9 @@ def hash_args(args: List[str]) -> str:
     return hash_compile_args(args, normalize_order=False)
 
 
-def store_command_hashes(commands: Dict[str, List[str]], cache_backend: Optional[Any]) -> int:
+def store_command_hashes(
+    commands: Dict[str, List[str]], cache_backend: Optional[CacheBackend]
+) -> int:
     """Store argument hashes for the given compile commands in SQLite."""
     if cache_backend is None:
         return 0
@@ -61,7 +68,7 @@ def store_command_hashes(commands: Dict[str, List[str]], cache_backend: Optional
     return stored
 
 
-def get_stored_args_hash(file_path: str, cache_backend: Optional[Any]) -> str:
+def get_stored_args_hash(file_path: str, cache_backend: Optional[CacheBackend]) -> str:
     """Return the stored argument hash for a file, or empty string."""
     if cache_backend is None:
         return ""
@@ -69,7 +76,9 @@ def get_stored_args_hash(file_path: str, cache_backend: Optional[Any]) -> str:
     return result or ""
 
 
-def has_args_changed(file_path: str, current_args: List[str], cache_backend: Optional[Any]) -> bool:
+def has_args_changed(
+    file_path: str, current_args: List[str], cache_backend: Optional[CacheBackend]
+) -> bool:
     """Return True if the stored argument hash differs from the current args."""
     stored_hash = get_stored_args_hash(file_path, cache_backend)
     if not stored_hash:
@@ -77,7 +86,7 @@ def has_args_changed(file_path: str, current_args: List[str], cache_backend: Opt
     return stored_hash != hash_args(current_args)
 
 
-def clear_stored_command_hashes(cache_backend: Optional[Any]) -> int:
+def clear_stored_command_hashes(cache_backend: Optional[CacheBackend]) -> int:
     """Clear all stored compilation argument hashes."""
     if cache_backend is None:
         return 0

--- a/clang_index_mcp/_compilation/include_extractor.py
+++ b/clang_index_mcp/_compilation/include_extractor.py
@@ -1,7 +1,9 @@
 """libclang-based implementation of the IncludeExtractor port."""
 
 from pathlib import Path
-from typing import Any, List
+from typing import List
+
+from clang.cindex import TranslationUnit
 
 from .._core import diagnostics
 
@@ -9,7 +11,7 @@ from .._core import diagnostics
 class ClangIncludeExtractor:
     """Extract include directives from a libclang TranslationUnit."""
 
-    def extract_includes(self, tu: Any, source_file: str) -> List[str]:
+    def extract_includes(self, tu: TranslationUnit, source_file: str) -> List[str]:
         """
         Return absolute paths of all files included by ``source_file`` according
         to the parsed translation unit ``tu``.

--- a/clang_index_mcp/_indexing/indexing_pipeline.py
+++ b/clang_index_mcp/_indexing/indexing_pipeline.py
@@ -8,7 +8,9 @@ and cache persistence.
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+from clang.cindex import TranslationUnit
 
 from .._core import diagnostics
 
@@ -154,7 +156,12 @@ class SingleFileIndexingPipeline:
         )
 
     def _handle_index_file_diagnostics(
-        self, file_path: str, tu: Any, current_hash: str, compile_args_hash: str, retry_count: int
+        self,
+        file_path: str,
+        tu: TranslationUnit,
+        current_hash: str,
+        compile_args_hash: str,
+        retry_count: int,
     ) -> Optional[str]:
         """Extract and process diagnostics. Returns error message if any."""
         return (  # type: ignore[no-any-return]
@@ -166,7 +173,7 @@ class SingleFileIndexingPipeline:
     def _finalize_index_success(
         self,
         file_path: str,
-        tu,
+        tu: TranslationUnit,
         current_hash: str,
         compile_args_hash: str,
         cache_error_msg: Optional[str],

--- a/clang_index_mcp/_indexing/ports/cache_backend.py
+++ b/clang_index_mcp/_indexing/ports/cache_backend.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from ..._symbols.model import SymbolInfo
+from ..._symbols.ports.parser import TypeAliasRecord
 
 
 @runtime_checkable
@@ -64,7 +65,7 @@ class CacheBackend(Protocol):
         """Remove cached data for a deleted file."""
         ...
 
-    def save_type_aliases_batch(self, aliases: List[Dict[str, Any]]) -> int:
+    def save_type_aliases_batch(self, aliases: List[TypeAliasRecord]) -> int:
         """Batch insert type aliases using transaction."""
         ...
 

--- a/clang_index_mcp/_persistence/cache_manager.py
+++ b/clang_index_mcp/_persistence/cache_manager.py
@@ -14,6 +14,7 @@ from .._indexing.ports.cache_backend import CacheBackend
 from .._persistence.cache_validation_context import CacheValidationContext
 from .._persistence.project_identity import ProjectIdentity
 from .._symbols.model import SymbolInfo
+from .._symbols.ports.parser import TypeAliasRecord
 
 if TYPE_CHECKING:
     from .._persistence.ports.recovery import CacheRecoveryPort
@@ -612,14 +613,14 @@ class CacheManager:
     # Type Aliases (Phase 1.3: Type Alias Tracking)
     # -------------------------------------------------------------------------
 
-    def save_type_aliases_batch(self, aliases: List[Dict[str, Any]]) -> int:
+    def save_type_aliases_batch(self, aliases: List[TypeAliasRecord]) -> int:
         """
         Batch save type aliases to cache.
 
         Phase 1.3: Type Alias Tracking - Wrapper for backend storage
 
         Args:
-            aliases: List of alias dictionaries
+            aliases: List of alias records
 
         Returns:
             Number of aliases successfully saved

--- a/clang_index_mcp/_persistence/sqlite_cache_backend.py
+++ b/clang_index_mcp/_persistence/sqlite_cache_backend.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .._symbols.model import SymbolInfo
+from .._symbols.ports.parser import TypeAliasRecord
 from .._persistence import type_alias_repository
 from .._persistence.repositories.symbol_repository import SymbolRepository
 from .._persistence.repositories.call_site_repository import CallSiteRepository
@@ -998,7 +999,7 @@ class SqliteCacheBackend:
     # Type Aliases Storage and Lookup (Phase 1.3: Type Alias Tracking)
     # -------------------------------------------------------------------------
 
-    def save_type_aliases_batch(self, aliases: List[Dict[str, Any]]) -> int:
+    def save_type_aliases_batch(self, aliases: List[TypeAliasRecord]) -> int:
         """Batch insert type aliases using transaction."""
         self._ensure_connected()
         return type_alias_repository.save_type_aliases_batch(self._conn, aliases)

--- a/clang_index_mcp/_persistence/type_alias_repository.py
+++ b/clang_index_mcp/_persistence/type_alias_repository.py
@@ -9,9 +9,10 @@ import sqlite3
 from typing import Any, Dict, List, Optional
 
 from .._core import diagnostics
+from .._symbols.ports.parser import TypeAliasRecord
 
 
-def save_type_aliases_batch(conn: sqlite3.Connection, aliases: List[Dict[str, Any]]) -> int:
+def save_type_aliases_batch(conn: sqlite3.Connection, aliases: List[TypeAliasRecord]) -> int:
     """Batch insert type aliases using a transaction."""
     if not aliases:
         return 0
@@ -28,18 +29,18 @@ def save_type_aliases_batch(conn: sqlite3.Connection, aliases: List[Dict[str, An
                 """,
                 [
                     (
-                        alias["alias_name"],
-                        alias["qualified_name"],
-                        alias["target_type"],
-                        alias["canonical_type"],
-                        alias["file"],
-                        alias["line"],
-                        alias["column"],
-                        alias["alias_kind"],
-                        alias["namespace"],
-                        1 if alias.get("is_template_alias", False) else 0,
-                        alias.get("template_params"),
-                        alias["created_at"],
+                        alias.alias_name,
+                        alias.qualified_name,
+                        alias.target_type,
+                        alias.canonical_type,
+                        alias.file,
+                        alias.line,
+                        alias.column,
+                        alias.alias_kind,
+                        alias.namespace,
+                        1 if alias.is_template_alias else 0,
+                        alias.template_params,
+                        alias.created_at,
                     )
                     for alias in aliases
                 ],

--- a/clang_index_mcp/_search/call_graph.py
+++ b/clang_index_mcp/_search/call_graph.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional, Set
 
 from .._symbols.model import SymbolInfo
+from .._symbols.ports.parser import CallSiteRecord
 
 
 class CallSite:
@@ -184,37 +185,21 @@ class CallGraphAnalyzer:
         # The calls/called_by fields were removed from SymbolInfo
         pass
 
-    def process_call_buffer(self, calls_buffer: List[Any]) -> None:
+    def process_call_buffer(self, calls_buffer: List[CallSiteRecord]) -> None:
         """Process buffered call records produced during indexing."""
         if not calls_buffer:
             return
 
-        for call_info in calls_buffer:
-            if len(call_info) == 7:
-                (
-                    caller_usr,
-                    called_usr,
-                    call_file,
-                    call_line,
-                    call_column,
-                    disp_name,
-                    tmpl_types,
-                ) = call_info
-                self.add_call(
-                    caller_usr,
-                    called_usr,
-                    call_file,
-                    call_line,
-                    call_column,
-                    display_name=disp_name,
-                    template_project_types=tmpl_types,
-                )
-            elif len(call_info) == 5:
-                caller_usr, called_usr, call_file, call_line, call_column = call_info
-                self.add_call(caller_usr, called_usr, call_file, call_line, call_column)
-            elif len(call_info) == 2:
-                caller_usr, called_usr = call_info
-                self.add_call(caller_usr, called_usr)
+        for record in calls_buffer:
+            self.add_call(
+                record.caller_usr,
+                record.callee_usr,
+                record.file,
+                record.line,
+                record.column,
+                display_name=record.display_name,
+                template_project_types=record.template_project_types,
+            )
 
     def restore_call_sites(self, call_sites_data: List[Dict[str, Any]]):
         """

--- a/clang_index_mcp/_search/dependency_graph.py
+++ b/clang_index_mcp/_search/dependency_graph.py
@@ -13,7 +13,9 @@ Key Features:
 The builder now depends on ports rather than concrete SQLite/libclang types.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
+from typing import TYPE_CHECKING, Dict, List, Set, Union
+
+from clang.cindex import TranslationUnit
 
 if TYPE_CHECKING:
     from .._search.ports.dependency_repository import DependencyRepository
@@ -46,7 +48,7 @@ class DependencyGraphBuilder:
         self._repository = repository
         self._include_extractor = include_extractor
 
-    def extract_includes_from_tu(self, tu: Any, source_file: str) -> List[str]:
+    def extract_includes_from_tu(self, tu: TranslationUnit, source_file: str) -> List[str]:
         """Extract all includes from a translation unit."""
         return self._include_extractor.extract_includes(tu, source_file)
 

--- a/clang_index_mcp/_search/ports/include_extractor.py
+++ b/clang_index_mcp/_search/ports/include_extractor.py
@@ -1,12 +1,14 @@
 """Port for extracting include directives from a parsed translation unit."""
 
-from typing import Any, List, Protocol
+from typing import List, Protocol
+
+from clang.cindex import TranslationUnit
 
 
 class IncludeExtractor(Protocol):
     """Extract absolute include paths from a parsed translation unit."""
 
-    def extract_includes(self, tu: Any, source_file: str) -> List[str]:
+    def extract_includes(self, tu: TranslationUnit, source_file: str) -> List[str]:
         """
         Return a list of absolute paths of files included by ``source_file``
         according to the parsed translation unit ``tu``.

--- a/clang_index_mcp/_symbols/alias_extractor.py
+++ b/clang_index_mcp/_symbols/alias_extractor.py
@@ -7,10 +7,11 @@ cursors and produces the normalized dictionaries consumed by SymbolExtractor.
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import List
 
-from clang.cindex import CursorKind
+from clang.cindex import Cursor, CursorKind
 
+from .._symbols.ports.parser import TypeAliasRecord
 from .cursor_utils import extract_namespace, get_qualified_name
 
 
@@ -27,7 +28,7 @@ class AliasInfoBase:
     column: int
 
     @classmethod
-    def from_cursor(cls, cursor: Any, target_type: str, canonical_type: str) -> "AliasInfoBase":
+    def from_cursor(cls, cursor: Cursor, target_type: str, canonical_type: str) -> "AliasInfoBase":
         """Create AliasInfoBase from cursor with extracted type information."""
         alias_name = cursor.spelling
         qualified_name = get_qualified_name(cursor)
@@ -60,7 +61,7 @@ class SimpleAliasInfo(AliasInfoBase):
     alias_kind: str
 
 
-def extract_template_alias_info(cursor: Any) -> TemplateAliasInfo:
+def extract_template_alias_info(cursor: Cursor) -> TemplateAliasInfo:
     """Extract alias info from a TYPE_ALIAS_TEMPLATE_DECL cursor."""
     template_params = []
     type_alias_decl = None
@@ -108,7 +109,7 @@ def extract_template_alias_info(cursor: Any) -> TemplateAliasInfo:
     )
 
 
-def extract_simple_alias_info(cursor: Any) -> SimpleAliasInfo:
+def extract_simple_alias_info(cursor: Cursor) -> SimpleAliasInfo:
     """Extract alias info from a TYPEDEF_DECL or TYPE_ALIAS_DECL cursor."""
     alias_name = cursor.spelling
     qualified_name = get_qualified_name(cursor)
@@ -144,7 +145,7 @@ def extract_simple_alias_info(cursor: Any) -> SimpleAliasInfo:
     )
 
 
-def extract_alias_info(cursor: Any) -> Dict[str, Any]:
+def extract_alias_info(cursor: Cursor) -> TypeAliasRecord:
     """Extract type alias information from TYPEDEF_DECL, TYPE_ALIAS_DECL, or TYPE_ALIAS_TEMPLATE_DECL cursor."""
     is_template_alias = cursor.kind == CursorKind.TYPE_ALIAS_TEMPLATE_DECL
 
@@ -161,17 +162,17 @@ def extract_alias_info(cursor: Any) -> Dict[str, Any]:
 
     namespace = extract_namespace(base_info.qualified_name)
 
-    return {
-        "alias_name": base_info.alias_name,
-        "qualified_name": base_info.qualified_name,
-        "target_type": base_info.target_type,
-        "canonical_type": base_info.canonical_type,
-        "file": base_info.file_path,
-        "line": base_info.line,
-        "column": base_info.column,
-        "alias_kind": alias_kind,
-        "namespace": namespace,
-        "is_template_alias": is_template_alias,
-        "template_params": json.dumps(template_params) if template_params else None,
-        "created_at": time.time(),
-    }
+    return TypeAliasRecord(
+        alias_name=base_info.alias_name,
+        qualified_name=base_info.qualified_name,
+        target_type=base_info.target_type,
+        canonical_type=base_info.canonical_type,
+        file=base_info.file_path,
+        line=base_info.line,
+        column=base_info.column,
+        alias_kind=alias_kind,
+        namespace=namespace,
+        is_template_alias=is_template_alias,
+        template_params=json.dumps(template_params) if template_params else None,
+        created_at=time.time(),
+    )

--- a/clang_index_mcp/_symbols/cursor_utils.py
+++ b/clang_index_mcp/_symbols/cursor_utils.py
@@ -5,14 +5,12 @@ logger.  Extracting them from SymbolExtractor breaks circular dependencies
 between the main extractor and smaller focused extractors (e.g. alias extraction).
 """
 
-from typing import Any
-
-from clang.cindex import CursorKind
+from clang.cindex import Cursor, CursorKind
 
 from .._core import diagnostics
 
 
-def get_qualified_name(cursor: Any) -> str:
+def get_qualified_name(cursor: Cursor) -> str:
     """Build fully qualified name by walking up semantic parent chain."""
     parts = []
     current = cursor

--- a/clang_index_mcp/_symbols/documentation_extractor.py
+++ b/clang_index_mcp/_symbols/documentation_extractor.py
@@ -5,12 +5,14 @@ from clang cursors and normalizes them, so SymbolExtractor does not need to own
 every small AST helper.
 """
 
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
+
+from clang.cindex import Cursor
 
 from .._core import diagnostics
 
 
-def extract_brief_comment(cursor: Any) -> Optional[str]:
+def extract_brief_comment(cursor: Cursor) -> Optional[str]:
     """Extract and truncate brief comment from cursor."""
     brief_comment = cursor.brief_comment
     if not brief_comment:
@@ -21,7 +23,7 @@ def extract_brief_comment(cursor: Any) -> Optional[str]:
     return brief
 
 
-def extract_raw_doc_comment(cursor: Any) -> Optional[str]:
+def extract_raw_doc_comment(cursor: Cursor) -> Optional[str]:
     """Extract and truncate full documentation comment from cursor."""
     raw_comment = cursor.raw_comment
     if not raw_comment:
@@ -43,7 +45,7 @@ def extract_brief_from_doc(doc_comment: str) -> Optional[str]:
     return None
 
 
-def extract_documentation(cursor: Any) -> Dict[str, Optional[str]]:
+def extract_documentation(cursor: Cursor) -> Dict[str, Optional[str]]:
     """Extract documentation from cursor comments."""
     result: Dict[str, Optional[str]] = {"brief": None, "doc_comment": None}
 

--- a/clang_index_mcp/_symbols/ports/call_graph.py
+++ b/clang_index_mcp/_symbols/ports/call_graph.py
@@ -1,8 +1,9 @@
 """Call graph port used by the symbol store during indexing and maintenance."""
 
-from typing import Any, List, Protocol
+from typing import List, Protocol
 
 from ..._symbols.model import SymbolInfo
+from .parser import CallSiteRecord
 
 
 class CallGraphPort(Protocol):
@@ -20,6 +21,6 @@ class CallGraphPort(Protocol):
         """Rebuild call graph state from a list of symbols (may be a no-op)."""
         ...
 
-    def process_call_buffer(self, calls_buffer: List[Any]) -> None:
+    def process_call_buffer(self, calls_buffer: List[CallSiteRecord]) -> None:
         """Add buffered call records to the call graph."""
         ...

--- a/clang_index_mcp/_symbols/ports/parser.py
+++ b/clang_index_mcp/_symbols/ports/parser.py
@@ -1,9 +1,42 @@
 """Parser port for the symbols/domain layer."""
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Protocol
+from typing import Callable, Dict, List, Optional, Protocol
+
+from clang.cindex import TranslationUnit
 
 from ..._symbols.model import SymbolInfo
+
+
+@dataclass(frozen=True)
+class CallSiteRecord:
+    """A single call record produced during AST traversal."""
+
+    caller_usr: str
+    callee_usr: str
+    file: Optional[str]
+    line: Optional[int]
+    column: Optional[int]
+    display_name: Optional[str] = None
+    template_project_types: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TypeAliasRecord:
+    """A type alias record produced during AST traversal."""
+
+    alias_name: str
+    qualified_name: str
+    target_type: str
+    canonical_type: str
+    file: str
+    line: int
+    column: int
+    alias_kind: str
+    namespace: str
+    is_template_alias: bool
+    template_params: Optional[str] = None
+    created_at: float = 0.0
 
 
 @dataclass
@@ -11,8 +44,8 @@ class ParseResult:
     """Result returned by a symbol parser after AST traversal."""
 
     symbols: List[SymbolInfo]
-    call_sites: List[Any]
-    type_aliases: List[Dict[str, Any]]
+    call_sites: List[CallSiteRecord]
+    type_aliases: List[TypeAliasRecord]
     processed_headers: Dict[str, str]
 
 
@@ -21,7 +54,7 @@ class SymbolParser(Protocol):
 
     def parse(
         self,
-        tu: Any,
+        tu: TranslationUnit,
         source_file: str,
         should_extract_from_file: Optional[Callable[[str], bool]] = None,
     ) -> ParseResult:

--- a/clang_index_mcp/_symbols/signature_builder.py
+++ b/clang_index_mcp/_symbols/signature_builder.py
@@ -7,17 +7,19 @@ separate makes it testable without instantiating the full SymbolExtractor.
 
 from typing import Any, List
 
+from clang.cindex import Cursor
+
 from .._core import diagnostics
 
 
-def get_type_spelling(cursor: Any):
+def get_type_spelling(cursor: Cursor):
     """Safely get cursor.type.spelling, returning None if unavailable."""
     if not cursor.type:
         return None
     return cursor.type.spelling or None
 
 
-def get_return_type(cursor: Any) -> str:
+def get_return_type(cursor: Cursor) -> str:
     """Safely get cursor.result_type.spelling."""
     try:
         if cursor.result_type and cursor.result_type.spelling:
@@ -89,7 +91,7 @@ def assemble_signature(return_type: str, name: str, params_str: str, qualifiers:
     return f"{name}({params_str}){qualifiers}"
 
 
-def fallback_signature(cursor: Any) -> str:
+def fallback_signature(cursor: Cursor) -> str:
     """Return cursor.type.spelling as a fallback, or empty string on failure."""
     try:
         return cursor.type.spelling if cursor.type else ""
@@ -97,7 +99,7 @@ def fallback_signature(cursor: Any) -> str:
         return ""
 
 
-def get_params_str(cursor: Any, type_spelling: str) -> str:
+def get_params_str(cursor: Cursor, type_spelling: str) -> str:
     """Get parameter string from cursor arguments or type spelling fallback."""
     try:
         args = list(cursor.get_arguments())
@@ -108,7 +110,7 @@ def get_params_str(cursor: Any, type_spelling: str) -> str:
         return extract_params_from_type_spelling(type_spelling)
 
 
-def _try_build_human_readable_signature(cursor: Any) -> str:
+def _try_build_human_readable_signature(cursor: Cursor) -> str:
     """Attempt to build signature without exception handling."""
     type_spelling = get_type_spelling(cursor)
     if type_spelling is None:
@@ -122,7 +124,7 @@ def _try_build_human_readable_signature(cursor: Any) -> str:
     return assemble_signature(return_type, name, params_str, qualifiers)
 
 
-def build_human_readable_signature(cursor: Any) -> str:
+def build_human_readable_signature(cursor: Cursor) -> str:
     """Build a human-readable function signature from a libclang cursor."""
     try:
         return _try_build_human_readable_signature(cursor)

--- a/clang_index_mcp/_symbols/symbol_extractor.py
+++ b/clang_index_mcp/_symbols/symbol_extractor.py
@@ -10,6 +10,8 @@ import json
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
+from clang.cindex import TranslationUnit
+
 from .._core import diagnostics
 from .._symbols.model import SymbolInfo
 from .._symbols.ports.parser import ParseResult, SymbolParser
@@ -194,7 +196,7 @@ class SymbolExtractor:
             except Exception as e:
                 diagnostics.warning(f"Error marking header {header} as completed: {e}")
 
-    def _update_dependency_graph(self, tu: Any, source_file: str):
+    def _update_dependency_graph(self, tu: TranslationUnit, source_file: str):
         """Extract and update dependencies for the given translation unit."""
         if self.dependency_graph is not None:
             try:
@@ -210,7 +212,7 @@ class SymbolExtractor:
         calls_buffer.extend(result.call_sites)
         aliases_buffer.extend(result.type_aliases)
 
-    def index_translation_unit(self, tu: Any, source_file: str) -> Dict[str, Any]:
+    def index_translation_unit(self, tu: TranslationUnit, source_file: str) -> Dict[str, Any]:
         """Process translation unit, extracting symbols from source and project headers."""
         processed_files: Set[str] = set()
         skipped_headers: Set[str] = set()


### PR DESCRIPTION
## Summary

Type-safety refactor across the symbol parsing and indexing pipeline.

## Changes

- Introduce typed dataclasses for parser outputs:
  - "CallSiteRecord"
  - "TypeAliasRecord"
  - "LineRangeInfo"
  - "CommonSymbolData"
- Replace loose "Any"/"Dict[str, Any]" annotations with concrete libclang types: "Cursor", "TranslationUnit", "Type", "Diagnostic".
- Update downstream consumers (cache backend, call-graph builder, alias repository, include extractors) to use typed records instead of dict access.

## Verification

- make test: 1455 passed, 17 skipped, 4 xpassed
- make format-check: passed
- make lint: passed
- make type-check: passed

## Notes

The ".vscode" directory was left untracked because it contains editor-local settings unrelated to this refactor.