### PR TITLE
docs: update AGENTS.md and CLAUDE.md for refactored package structure

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -124,13 +124,21 @@ This ensures local checks match GitHub CI exactly.
 
 Most changes will touch one of these areas:
 
-- `clang_index_mcp/cpp_mcp_server.py`: MCP tool schemas and request handlers.
-- `clang_index_mcp/cpp_analyzer.py`: core indexing pipeline, AST traversal, symbol extraction, and worker logic.
-- `clang_index_mcp/call_graph.py`: SQLite-backed call graph storage and queries.
-- `clang_index_mcp/sqlite_cache_backend.py`: schema management, SQLite tuning, and persistence behavior.
-- `clang_index_mcp/incremental_analyzer.py`: change detection and incremental refresh behavior.
-- `clang_index_mcp/compile_commands_manager.py`: compile_commands.json loading and lookup.
-- `clang_index_mcp/header_tracker.py`: header deduplication logic.
+- `clang_index_mcp/_mcp/cpp_mcp_server.py`: MCP server entry point and tool dispatch.
+- `clang_index_mcp/_mcp/consolidated_tools.py`: public MCP tool schemas (10 consolidated tools).
+- `clang_index_mcp/_mcp/tool_handlers/*.py`: internal tool handlers.
+- `clang_index_mcp/cpp_analyzer.py`: thin facade over the analyzer.
+- `clang_index_mcp/composition_root.py`: dependency wiring.
+- `clang_index_mcp/_indexing/indexing_orchestrator.py`: full-project indexing flow.
+- `clang_index_mcp/_indexing/indexing_pipeline.py`: single-file indexing pipeline.
+- `clang_index_mcp/_symbols/symbol_extractor.py`: symbol extraction coordination.
+- `clang_index_mcp/_compilation/clang_symbol_parser.py`: libclang AST traversal.
+- `clang_index_mcp/_search/call_graph.py`, `clang_index_mcp/_search/call_graph_service.py`: SQLite-backed call graph storage and queries.
+- `clang_index_mcp/_persistence/sqlite_cache_backend.py`: schema management, SQLite tuning, and persistence behavior.
+- `clang_index_mcp/_persistence/schema.sql`: database schema.
+- `clang_index_mcp/_incremental/incremental_analyzer.py`: change detection and incremental refresh behavior.
+- `clang_index_mcp/_compilation/compile_commands_manager.py`: compile_commands.json loading and lookup.
+- `clang_index_mcp/_persistence/header_tracker.py`: header deduplication logic.
 
 Treat the following behaviors as critical unless the task explicitly requires changing them:
 
@@ -154,9 +162,9 @@ Treat the following behaviors as critical unless the task explicitly requires ch
 
 - Preserve the current code style and naming patterns.
 - Keep schema changes coordinated:
-  - Update `clang_index_mcp/schema.sql`.
+  - Update `clang_index_mcp/_persistence/schema.sql`.
   - Increment the schema version there.
-  - Update `CURRENT_SCHEMA_VERSION` in `clang_index_mcp/sqlite_cache_backend.py`.
+  - Update `CURRENT_SCHEMA_VERSION` in `clang_index_mcp/_persistence/sqlite_cache_backend.py`.
 - Add or update tests whenever behavior changes.
 - Update documentation when user-visible behavior, architecture, or workflows change.
 - Do not revert unrelated user changes in the worktree.

--- a/.ai/CLAUDE.md
+++ b/.ai/CLAUDE.md
@@ -182,6 +182,18 @@ make ie                         # install-editable
   │  └────────────────────────────────────────── CacheManager
   │                                              └─ SQLiteCacheBackend (FTS5)
   └───────────────────────────────────────────── FileScanner
+
+Refactored into packages:
+- `_mcp/` — MCP server, tool registry, and consolidated tools
+- `_indexing/` — indexing orchestration, pipeline, refresh, worker pool
+- `_symbols/` — symbol model, extraction, parser port
+- `_compilation/` — libclang parsing, compile commands, compilation environment
+- `_search/` — query engine, search engine, call graph, hierarchy, dependency graph
+- `_persistence/` — SQLite backend, repositories, cache manager, project identity, header tracker
+- `_incremental/` — incremental analysis and change scanning
+- `_core/` — shared utilities, file scanner, concurrency, cancellation
+- `composition_root.py` — dependency wiring
+- `cpp_analyzer.py` — thin public facade
 ```
 
 ### Key Architectural Decisions
@@ -198,14 +210,14 @@ make ie                         # install-editable
 - First source file to include a header "claims" it via `HeaderProcessingTracker`
 - 5-10x performance improvement for commonly-included headers
 - Identity tracked by header path only (not compile args)
-- See clang_index_mcp/header_tracker.py
+- See clang_index_mcp/_persistence/header_tracker.py
 
 **3. Incremental Analysis Architecture**
 - Tracks file changes via MD5 hashing (content-based, platform-independent)
 - Builds dependency graphs to cascade header changes to dependent sources
 - Detects compile_commands.json changes and re-analyzes affected files
 - Provides 30-300x speedup for partial refreshes
-- See clang_index_mcp/incremental_analyzer.py, clang_index_mcp/change_scanner.py
+- See clang_index_mcp/_incremental/incremental_analyzer.py, clang_index_mcp/_incremental/change_scanner.py
 - **Resource Management and File Descriptor Handling**
 - **CRITICAL:** TranslationUnit objects are deleted immediately after symbol extraction
 - `del tu` + `gc.collect()` forces cleanup of libclang C++ resources (file descriptors)
@@ -213,22 +225,23 @@ make ie                         # install-editable
 - Singleton analyzer per worker process (not per file) reduces SQLite connections
 - File descriptors remain stable at ~10-15 during indexing (tested with 5700+ files)
 - **Historical Issue:** self.translation_units dict was removed (write-only, caused 516+ FD leak)
-- See clang_index_mcp/cpp_analyzer.py:3322 (explicit TU deletion), :161-191 (worker cleanup)
-- See clang_index_mcp/header_tracker.py
+- See `clang_index_mcp/_indexing/indexing_pipeline.py` (`SingleFileIndexingPipeline._finalize_index_success()`) for explicit TU deletion
+- See `clang_index_mcp/_indexing/worker_pool.py` (`_process_file_worker()`) for worker cleanup
+- See `clang_index_mcp/_persistence/header_tracker.py`
 
 **5. SQLite Cache with FTS5**
 - Symbol storage in SQLite with full-text search (2-5ms for 100K symbols)
 - WAL mode for concurrent multi-process access
 - Automatic VACUUM, OPTIMIZE, and ANALYZE maintenance
 - Cache per project configuration: (source_dir, config_file) → unique cache dir
-- See clang_index_mcp/sqlite_cache_backend.py, clang_index_mcp/schema.sql
+- See clang_index_mcp/_persistence/sqlite_cache_backend.py, clang_index_mcp/_persistence/schema.sql
 
 **6. Compile Commands Integration**
 - Parses compile_commands.json for accurate per-file compilation arguments
 - Binary caching (.mcp_cache/<project>/compile_commands/<hash>.cache) for 10-100x faster startup
 - Optional orjson for 3-5x faster JSON parsing (pip install .[performance])
 - Fallback to hardcoded args if compile_commands.json not found
-- See clang_index_mcp/compile_commands_manager.py
+- See clang_index_mcp/_compilation/compile_commands_manager.py
 
 **7. No Runtime Monitoring of compile_commands.json**
 - Only checked on analyzer startup (not during runtime)
@@ -240,7 +253,7 @@ make ie                         # install-editable
 - Eliminates race conditions in multi-process mode (was causing ~5000 writes for large projects)
 - Cached as header_tracker.json in project cache directory
 - Includes compile_commands.json hash for invalidation on config changes
-- See clang_index_mcp/header_tracker.py, cpp_analyzer.py:_save_header_tracking()
+- See clang_index_mcp/_persistence/header_tracker.py and clang_index_mcp/_persistence/cache_orchestrator.py (`save_header_tracking()`)
 
 **9. libclang Error Recovery**
 - Leverages libclang's built-in error recovery for non-fatal parse errors
@@ -248,7 +261,7 @@ make ie                         # install-editable
 - Only TranslationUnitLoadError (no TU created) causes true failure
 - Errors logged as warnings, cached with error_message for diagnostics
 - Provides 90%+ symbol extraction vs 0% for files with minor issues
-- See cpp_analyzer.py:index_file() error handling
+- See clang_index_mcp/_indexing/indexing_pipeline.py (`SingleFileIndexingPipeline.index_file()`) for error handling
 
 **10. AST Traversal Optimization (System Header Skipping)**
 - Early exit from AST traversal when encountering non-project file cursors
@@ -256,29 +269,39 @@ make ie                         # install-editable
 - Provides 5-7x speedup on large projects (3.5 hours → ~30-60 minutes for 5700 files)
 - Safe because: symbol extraction already filtered, dependency discovery uses tu.get_includes() API
 - Only traverses AST nodes from project files and files with active call tracking
-- See cpp_analyzer.py:_process_cursor() early exit optimization (line ~2551-2553)
+- See `clang_index_mcp/_compilation/clang_symbol_parser.py` (`ClangSymbolParser._process_cursor()`) for the early-exit optimization
 
-**11. SQLite PRAGMAs:** Applied per-connection in `_set_connection_pragmas()` (WAL, 64MB cache, 256MB mmap). CRITICAL: must be applied to every connection — workers with `skip_schema_recreation=True` bypassed schema init and missed PRAGMAs (>8x perf regression). See `sqlite_cache_backend.py:_set_connection_pragmas()`.
+**11. SQLite PRAGMAs:** Applied per-connection in `_set_connection_pragmas()` (WAL, 64MB cache, 256MB mmap). CRITICAL: must be applied to every connection — workers with `skip_schema_recreation=True` bypassed schema init and missed PRAGMAs (>8x perf regression). See `clang_index_mcp/_persistence/sqlite_cache_backend.py` (`SqliteCacheBackend._set_connection_pragmas()`).
 
-**12. Call Graph in SQLite only:** No in-memory call_graph dicts (was ~2 GB RAM). Workers stream call_sites directly to SQLite; find_callers/find_callees query on-demand. See `clang_index_mcp/call_graph.py`.
+**12. Call Graph in SQLite only:** No in-memory call_graph dicts (was ~2 GB RAM). Workers stream call_sites directly to SQLite; find_callers/find_callees query on-demand. See `clang_index_mcp/_search/call_graph.py`.
 
-**13. Template-Mediated Calls:** `std::make_shared<T>()` tracked via template arg type extraction at parse time. `is_template_mediated: True` flag in find_callees results. See `_extract_template_call_info()`.
+**13. Template-Mediated Calls:** `std::make_shared<T>()` tracked via template arg type extraction at parse time. `is_template_mediated: True` flag in find_callees results. See `clang_index_mcp/_compilation/clang_symbol_parser.py` (`ClangSymbolParser._extract_template_call_info()`).
 
 
 ### Critical Code Locations
 
-- **MCP Tools Definition:** clang_index_mcp/cpp_mcp_server.py:127-312 (`list_tools()`)
-- **Core Analyzer:** clang_index_mcp/cpp_analyzer.py:512 (CppAnalyzer class)
-- **Symbol Extraction:** clang_index_mcp/cpp_analyzer.py:2536 (`_process_cursor()` recursive AST traversal)
-- **Type Alias Extraction:** clang_index_mcp/cpp_analyzer.py:2393 (`_extract_alias_info()` handles TYPE_ALIAS_DECL and TYPE_ALIAS_TEMPLATE_DECL, extracts template parameters)
-- **Documentation Extraction (Phase 2):** clang_index_mcp/cpp_analyzer.py:2044 (`_extract_documentation()` brief and doc_comment extraction)
-- **Virtual Method Extraction (Phase 5):** clang_index_mcp/cpp_analyzer.py:2536 (`_process_cursor()` internals: cursor.is_virtual_method(), is_pure_virtual_method(), is_const_method(), is_static_method())
-- **Parallel Worker:** clang_index_mcp/cpp_analyzer.py:86-193 (`_process_file_worker()` with singleton-per-process pattern and atexit cleanup)
-- **Call Graph Analysis (Phase 4):** clang_index_mcp/call_graph.py (SQLite-only queries, no in-memory dicts)
-- **SQLite FTS5:** clang_index_mcp/sqlite_cache_backend.py, clang_index_mcp/schema.sql (v17.0 — see schema.sql for current column list)
-- **Header Tracking:** clang_index_mcp/header_tracker.py (HeaderProcessingTracker)
-- **Incremental Logic:** clang_index_mcp/incremental_analyzer.py
-- **Compile Commands:** clang_index_mcp/compile_commands_manager.py
+- **MCP Server Entry Point:** `clang_index_mcp/_mcp/cpp_mcp_server.py`
+- **Public Tool Schemas:** `clang_index_mcp/_mcp/consolidated_tools.py` (`list_tools_b()`)
+- **Internal Tool Handlers:** `clang_index_mcp/_mcp/tool_handlers/*.py`
+- **Analyzer Facade:** `clang_index_mcp/cpp_analyzer.py` (`CppAnalyzer`)
+- **Dependency Wiring:** `clang_index_mcp/composition_root.py` (`CompositionRoot`)
+- **Project Context / DI Container:** `clang_index_mcp/project_context.py` (`ProjectContext`)
+- **Full-Project Indexing:** `clang_index_mcp/_indexing/indexing_orchestrator.py` (`ProjectIndexingOrchestrator`)
+- **Single-File Indexing Pipeline:** `clang_index_mcp/_indexing/indexing_pipeline.py` (`SingleFileIndexingPipeline`)
+- **Worker Pool:** `clang_index_mcp/_indexing/worker_pool.py` (`_process_file_worker()`)
+- **Symbol Extraction Coordination:** `clang_index_mcp/_symbols/symbol_extractor.py` (`SymbolExtractor.index_translation_unit()`)
+- **AST Traversal:** `clang_index_mcp/_compilation/clang_symbol_parser.py` (`ClangSymbolParser._process_cursor()`)
+- **Type Alias Extraction:** `clang_index_mcp/_symbols/alias_extractor.py` (`extract_alias_info()`)
+- **Documentation Extraction:** `clang_index_mcp/_symbols/documentation_extractor.py` (`extract_documentation()`)
+- **Virtual Method Indicators:** `clang_index_mcp/_compilation/clang_symbol_parser.py` (method indicator extraction in `_process_cursor()`)
+- **Symbol Model:** `clang_index_mcp/_symbols/model/symbol_info.py` (`SymbolInfo`)
+- **Symbol Index Store:** `clang_index_mcp/_symbols/symbol_index_store.py` (`SymbolIndexStore`)
+- **Call Graph Analysis:** `clang_index_mcp/_search/call_graph.py`, `clang_index_mcp/_search/call_graph_service.py`
+- **SQLite Backend:** `clang_index_mcp/_persistence/sqlite_cache_backend.py`
+- **Schema:** `clang_index_mcp/_persistence/schema.sql` (v17.0)
+- **Header Tracking:** `clang_index_mcp/_persistence/header_tracker.py` (`HeaderProcessingTracker`)
+- **Incremental Logic:** `clang_index_mcp/_incremental/incremental_analyzer.py`
+- **Compile Commands:** `clang_index_mcp/_compilation/compile_commands_manager.py`
 
 ## Configuration
 
@@ -381,22 +404,24 @@ The `diagnose_parse_errors.py` script tests parsing with different libclang opti
 ## Common Workflows
 
 ### Adding a New MCP Tool
-1. Define tool schema in `cpp_mcp_server.py` `list_tools()` function
-2. Add handler in `cpp_mcp_server.py` `call_tool()` function
-3. Implement analyzer method in `cpp_analyzer.py`
-4. Add tests in `tests/test_*.py`
-5. Update this CLAUDE.md if architecturally significant
+1. Define the public tool schema in `clang_index_mcp/_mcp/consolidated_tools.py` (`list_tools_b()`)
+2. Add the consolidated handler in `clang_index_mcp/_mcp/consolidated_tools.py` (`handle_tool_call_b()`)
+3. Add the internal handler in `clang_index_mcp/_mcp/tool_handlers/*.py` and register it via `ToolRegistry`
+4. Implement analyzer logic in `clang_index_mcp/_search/query_engine.py`, `clang_index_mcp/_search/call_graph_service.py`, or `clang_index_mcp/_symbols/symbol_extractor.py` as appropriate
+5. Add tests in `tests/test_*.py`
+6. Update this CLAUDE.md if architecturally significant
 
 ### Modifying Symbol Extraction Logic
-1. Edit `cpp_analyzer.py` `_process_cursor()` (recursive AST walker)
-2. Update `symbol_info.py` if changing SymbolInfo structure
-3. If changing SQLite schema:
-   - Update `clang_index_mcp/schema.sql` with new columns/tables
-   - Increment schema version in schema.sql (e.g., "4.0" → "5.0")
-   - Update `CURRENT_SCHEMA_VERSION` in `sqlite_cache_backend.py`
+1. Edit `clang_index_mcp/_compilation/clang_symbol_parser.py` (`ClangSymbolParser._process_cursor()` recursive AST walker)
+2. Update `clang_index_mcp/_symbols/model/symbol_info.py` if changing `SymbolInfo` structure
+3. Update extractors in `clang_index_mcp/_symbols/` (`alias_extractor.py`, `documentation_extractor.py`, etc.) as needed
+4. If changing SQLite schema:
+   - Update `clang_index_mcp/_persistence/schema.sql` with new columns/tables
+   - Increment the schema version in `schema.sql`
+   - Update `CURRENT_SCHEMA_VERSION` in `clang_index_mcp/_persistence/sqlite_cache_backend.py`
    - Database will automatically recreate on version mismatch (development mode)
-4. Run `make test` to verify no regressions
-5. Test with example project: `python -m clang_index_mcp` + set examples/compile_commands_example/
+5. Run `make test` to verify no regressions
+6. Test with example project: `python -m clang_index_mcp` + set `examples/compile_commands_example/`
 
 ### Cache Invalidation and Corruption Recovery
 
@@ -479,7 +504,7 @@ If auto-download fails, manually download from https://github.com/llvm/llvm-proj
 
 9. **SQLite cache:** Lives in `.mcp_cache/` (multi-config support). Compile commands cache stored in `.mcp_cache/<project>/compile_commands/`. Safe to delete for fresh indexing. WAL mode enables concurrent access. **Schema version 17.0** includes virtual method indicators (is_virtual, is_pure_virtual, is_const, is_static), type_aliases table with template_params support, documentation fields (brief, doc_comment), call_sites table for line-level call graph tracking, and template-mediated call metadata (display_name, template_project_types).
 
-10. **Development mode auto-recreation:** During development, the SQLite database is automatically recreated when the schema version changes. This simplifies development by avoiding migration complexity. When you change `schema.sql`, just increment the version number and update `CURRENT_SCHEMA_VERSION` in `sqlite_cache_backend.py`. On next run, the old database will be deleted and recreated with the new schema.
+10. **Development mode auto-recreation:** During development, the SQLite database is automatically recreated when the schema version changes. This simplifies development by avoiding migration complexity. When you change `clang_index_mcp/_persistence/schema.sql`, just increment the version number and update `CURRENT_SCHEMA_VERSION` in `clang_index_mcp/_persistence/sqlite_cache_backend.py`. On next run, the old database will be deleted and recreated with the new schema.
 
 11. **Parse error recovery:** The analyzer leverages libclang's error recovery to extract symbols from files with non-fatal parsing errors. Files with syntax or semantic errors will log warnings but continue processing, extracting partial symbols from the usable AST. Only true fatal errors (no TranslationUnit created) cause file rejection. This means you get partial results instead of nothing for files with minor issues.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,277 @@
+# C++ Analyzer Architecture
+
+An MCP server that indexes C++ projects with libclang and exposes semantic query tools.
+
+## Overview
+
+Core responsibilities:
+
+- **Indexing**: parse C++ files with libclang, extract symbols, call sites, type aliases, and dependencies.
+- **Persistence**: store extracted data in SQLite with FTS5 and WAL mode.
+- **Querying**: search symbols, class hierarchies, call graphs, and type aliases.
+- **Incremental refresh**: detect changed files via content hashes and re-analyze only affected files.
+
+## Clean Architecture Mapping
+
+| Layer | Directory / Key Files | Responsibility |
+|---|---|---|
+| **Domain** | `_symbols/model/symbol_info.py` | `SymbolInfo` and domain helpers |
+| | `_symbols/ports/parser.py` | `SymbolParser` port, `ParseResult`, `CallSiteRecord`, `TypeAliasRecord` |
+| | `_search/ports/search_deps.py` | Search-layer dependency protocols |
+| | `_indexing/ports/cache_backend.py` | `CacheBackend` port |
+| | `_persistence/ports/recovery.py` | `CacheRecoveryPort` |
+| **Use Cases** | `_indexing/indexing_orchestrator.py` | Full project indexing orchestration |
+| | `_indexing/indexing_pipeline.py` | Single-file indexing pipeline |
+| | `_indexing/refresh_pipeline.py` | Incremental refresh |
+| | `_symbols/symbol_extractor.py` | Coordinates AST-based symbol extraction |
+| | `_search/query_engine.py` | Search and analysis queries |
+| | `_search/call_graph_service.py` | Call graph queries |
+| | `_incremental/incremental_analyzer.py` | Change detection and cascade re-analysis |
+| | `_incremental/change_scanner.py` | MD5-based change scanning |
+| **Interface Adapters** | `_mcp/cpp_mcp_server.py`, `_mcp/tool_handlers/*.py` | MCP tools and transport |
+| | `_persistence/sqlite_cache_backend.py` | SQLite `CacheBackend` implementation |
+| | `_persistence/repositories/*.py` | SQLite repositories |
+| | `_compilation/compile_commands_manager.py` | `compile_commands.json` loading and caching |
+| | `_compilation/compilation_environment.py` | Compile args and file scanning |
+| **Frameworks / Drivers** | `_compilation/clang_parser.py`, `_compilation/clang_symbol_parser.py` | libclang parsing |
+| | `_core/libclang_setup.py`, `_core/file_scanner.py` | libclang setup and file discovery |
+| | `_indexing/worker_pool.py` | `ProcessPoolExecutor` |
+| | `libclang/` | libclang binaries |
+
+### Dependency Rule
+
+Dependencies point inward: frameworks depend on adapters, adapters depend on use cases, use cases depend on domain. Wiring is centralized in `composition_root.py`.
+
+## Functional Domains
+
+```
+┌─────────────────────────────────────────┐
+│ MCP Tools & Transport                   │
+│ _mcp/cpp_mcp_server.py                  │
+│ _mcp/tool_handlers/                     │
+│ _mcp/transport/                         │
+├─────────────────────────────────────────┤
+│ Query & Analysis                        │
+│ _search/query_engine.py                 │
+│ _search/search_engine.py                │
+│ _search/call_graph_service.py           │
+│ _search/hierarchy_analyzer.py           │
+├─────────────────────────────────────────┤
+│ Symbol Extraction                       │
+│ _symbols/symbol_extractor.py            │
+│ _symbols/model/                         │
+│ _compilation/clang_symbol_parser.py     │
+├─────────────────────────────────────────┤
+│ Indexing Orchestration                  │
+│ _indexing/indexing_orchestrator.py      │
+│ _indexing/indexing_pipeline.py          │
+│ _indexing/refresh_pipeline.py           │
+│ _incremental/                           │
+├─────────────────────────────────────────┤
+│ Persistence & Project Identity          │
+│ _persistence/sqlite_cache_backend.py    │
+│ _persistence/repositories/              │
+│ _persistence/cache_manager.py           │
+│ _persistence/project_identity.py        │
+├─────────────────────────────────────────┤
+│ Compilation Environment                 │
+│ _compilation/compile_commands_manager.py│
+│ _compilation/compilation_environment.py │
+│ _compilation/clang_parser.py            │
+├─────────────────────────────────────────┤
+│ Shared Infrastructure                   │
+│ _core/file_scanner.py                   │
+│ _core/libclang_setup.py                 │
+│ _core/concurrency_context.py            │
+│ _core/cancellation_coordinator.py       │
+└─────────────────────────────────────────┘
+```
+
+## Module Dependency Graph
+
+```mermaid
+graph TD
+    subgraph Domain
+        MODEL[_symbols/model/symbol_info.py]
+        PORTS[_symbols/ports/<br/>_search/ports/<br/>_indexing/ports/<br/>_persistence/ports/]
+    end
+
+    subgraph UseCases
+        IDX[_indexing/indexing_orchestrator.py<br/>indexing_pipeline.py<br/>refresh_pipeline.py]
+        SE[_symbols/symbol_extractor.py]
+        QE[_search/query_engine.py]
+        CGS[_search/call_graph_service.py]
+        INC[_incremental/]
+    end
+
+    subgraph Adapters
+        MCP[_mcp/cpp_mcp_server.py<br/>tool_handlers/]
+        SQLite[_persistence/sqlite_cache_backend.py]
+        REPO[_persistence/repositories/]
+        CCM[_compilation/compile_commands_manager.py]
+        CE[_compilation/compilation_environment.py]
+    end
+
+    subgraph Drivers
+        L[_core/libclang_setup.py]
+        FS[_core/file_scanner.py]
+        WP[_indexing/worker_pool.py]
+        CP[_compilation/clang_parser.py]
+    end
+
+    MCP --> QE
+    MCP --> CGS
+    MCP --> IDX
+    IDX --> SE
+    IDX --> WP
+    SE --> PORTS
+    SE --> CE
+    SE --> CGS
+    QE --> PORTS
+    CGS --> REPO
+    CGS --> SQLite
+    INC --> IDX
+    CE --> CCM
+    CE --> FS
+    REPO --> SQLite
+    IDX --> SQLite
+    CP --> L
+```
+
+## Execution Model
+
+The server runs one main process and spawns worker processes for indexing.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Main Process                                                │
+│  • MCP server                                               │
+│  • CppAnalyzer facade                                       │
+│  • CompositionRoot / ProjectContext                         │
+│  • SymbolIndexStore (in-memory indexes)                     │
+│  • SQLite cache manager                                     │
+└───────────────────────┬─────────────────────────────────────┘
+                        │ spawn
+        ┌───────────────┼───────────────┐
+        ▼               ▼               ▼
+┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+│ Worker 1     │ │ Worker 2     │ │ Worker N     │
+│  • own Index │ │  • own Index │ │  • own Index │
+│  • own TU    │ │  • own TU    │ │  • own TU    │
+│  • parses    │ │  • parses    │ │  • parses    │
+│    one file  │ │    one file  │ │    one file  │
+└──────────────┘ └──────────────┘ └──────────────┘
+        │               │               │
+        └───────────────┼───────────────┘
+                        ▼
+        Results merged into main process indexes and SQLite
+```
+
+- Workers use `spawn` multiprocessing for fork safety.
+- Each worker lazily creates a single `CppAnalyzer` instance per process.
+- Workers do not share memory with the main process or each other.
+- SQLite with WAL mode is the shared persistent store.
+
+## Concurrency & IPC
+
+### Worker-to-Main Data Flow
+
+```mermaid
+sequenceDiagram
+    participant MP as Main Process
+    participant WP as Worker Process
+    participant DB as SQLite
+
+    MP->>WP: submit(IndexingTaskSpec)
+    Note over WP: parse + AST traversal
+    WP->>WP: fill thread-local buffers
+    WP->>WP: bulk_write_symbols() to local indexes
+    WP->>DB: save_type_aliases_batch()
+    WP->>DB: save_file_cache()
+    opt parse failure
+        WP->>DB: log_parse_error()
+    end
+    WP->>WP: collect symbols, call_sites, processed_headers
+    WP->>WP: clear local indexes + gc.collect()
+    WP-->>MP: Future.result(...)
+
+    MP->>MP: WorkerResultMerger.merge_worker_result()
+    MP->>MP: with index_lock: update SymbolIndexStore
+    MP->>DB: stream_call_sites(file_path, call_sites)
+    MP->>MP: update header tracker
+```
+
+### What Workers Write Directly vs Return
+
+| Data | Worker Action | Main Process Action | Storage |
+|---|---|---|---|
+| Symbols | Extract and return via `Future` | Merge into in-memory `SymbolIndexStore` | In-memory + file cache in SQLite |
+| Call sites | Extract and return via `Future` | Atomically replace per-file entries in SQLite | SQLite |
+| Type aliases | Write batch directly to SQLite | — | SQLite |
+| File cache | Write directly to SQLite | — | SQLite |
+| Parse errors | Append directly to JSONL | Read on demand | JSONL file |
+| Processed headers | Return via `Future` | Update `HeaderProcessingTracker` | In-memory + `header_tracker.json` |
+
+Call sites go through the main process because they require atomic per-file replacement (`DELETE` old + `INSERT` new). Type aliases and file cache are simple batch writes, so workers write them directly to reduce IPC.
+
+### Lock Minimization
+
+- Workers parse and extract independently. They never hold the main process `index_lock`.
+- `SymbolExtractor` uses thread-local buffers during AST traversal and acquires a lock only once for `bulk_write_symbols()`.
+- The main process `index_lock` is held only for the brief merge of one file's results.
+- SQLite WAL mode separates readers from writers; a busy handler resolves short conflicts.
+
+### Synchronization Primitives
+
+| Primitive | Type | Protects | Location |
+|---|---|---|---|
+| `ConcurrencyContext.index_lock` | `threading.RLock` | Main process `SymbolIndexStore` | `_core/concurrency_context.py` |
+| Worker-local lock | `threading.RLock` | Worker-local `SymbolIndexStore` | per-worker `ConcurrencyContext` |
+| `AnalyzerStateManager._lock` | `threading.Lock` | State + active tool counter | `_mcp/state_manager.py` |
+| `_tools_event` | `threading.Event` | Tool-call priority over indexing | `_mcp/state_manager.py` |
+| `_indexed_event` | `threading.Event` | Completion signal for indexing | `_mcp/state_manager.py` |
+| SQLite WAL + busy handler | SQLite | Persistent cache | `_persistence/sqlite_cache_backend.py` |
+| Header tracker lock | `threading.Lock` | `HeaderProcessingTracker` state | `_persistence/header_tracker.py` |
+
+### Indexing vs Query Synchronization
+
+The analyzer lifecycle is managed by `AnalyzerStateManager`:
+
+```mermaid
+stateDiagram-v2
+    [*] --> UNINITIALIZED
+    UNINITIALIZED --> INITIALIZING : set_project_directory
+    INITIALIZING --> INDEXING : background task
+    INDEXING --> INDEXED : done
+    INDEXED --> REFRESHING : refresh_project
+    REFRESHING --> INDEXED : done
+    INDEXING --> ERROR : failure
+    REFRESHING --> ERROR : failure
+
+    note right of INDEXING
+        query_behavior = allow_partial:
+        queries run against partial index
+    end note
+```
+
+- Query tools are rejected when the analyzer is `UNINITIALIZED`, `INITIALIZING`, or `ERROR`.
+- Query behavior is controlled by `query_behavior` config: `allow_partial`, `block`, or `reject`.
+- Tool handlers wrap execution in `state_manager.tool_execution()`, incrementing an active-tool counter.
+- Indexing callbacks call `wait_for_tools_to_finish()` between files, giving active tool calls priority.
+
+## File-to-Function Cheat Sheet
+
+| Task | Files |
+|---|---|
+| Add or change an MCP tool | `_mcp/tool_handlers/*.py`, `_mcp/tool_registry.py`, `_mcp/consolidated_tools.py` |
+| Change symbol extraction | `_symbols/symbol_extractor.py`, `_compilation/clang_symbol_parser.py` |
+| Change result model | `_symbols/model/symbol_info.py` |
+| Change search behavior | `_search/query_engine.py`, `_search/search_engine.py` |
+| Change call graph behavior | `_search/call_graph_service.py`, `_search/call_graph.py` |
+| Change SQLite schema | `clang_index_mcp/schema.sql`, `_persistence/sqlite_cache_backend.py` (`CURRENT_SCHEMA_VERSION`) |
+| Change incremental refresh | `_incremental/incremental_analyzer.py`, `_incremental/change_scanner.py`, `_search/dependency_graph.py` |
+| Change header deduplication | `_persistence/header_tracker.py` |
+| Change parallel execution | `_indexing/worker_pool.py`, `_indexing/indexing_task_submitter.py`, `_indexing/worker_result_merger.py` |
+| Change compilation args / compile_commands | `_compilation/compile_commands_manager.py`, `_compilation/compilation_environment.py` |
+| Wire dependencies | `composition_root.py` |
+| Thin public API | `cpp_analyzer.py` |


### PR DESCRIPTION
## Summary
Updates the project documentation to match the current refactored package layout and adds a dedicated architecture guide for new contributors and LLM-based tooling.

## Changes

### `.ai/AGENTS.md`
- Updated Architecture Hotspots to point to the new package locations (e.g., `clang_index_mcp/_persistence/schema.sql`, `clang_index_mcp/_persistence/sqlite_cache_backend.py`).
- Removed stale paths and module references.

### `.ai/CLAUDE.md`
- Refreshed Critical Code Locations and Common Workflows sections to reflect the refactored directory structure.
- Dropped outdated line numbers and obsolete directory listings.

### `docs/ARCHITECTURE.md` (new)
- Clean Architecture layer mapping for the MCP server implementation.
- Functional-domain overview: indexing, search, call graph, class hierarchy, and type-alias tracking.
- Execution model with process responsibilities.
- Concurrency and IPC section, including worker-to-database synchronization designed to minimize worker lock contention.

## Verification
- `make format-check`, `make lint`, and `make type-check` passed locally.
- Full test suite passed locally: `1455 passed, 17 skipped, 4 xpassed`.

## Notes
- No production code is changed.
