### PR TITLE
test: clean up .mcp_cache directories created during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,11 @@ from tests.utils.test_helpers import (
     temp_project,
 )
 
+def _cache_base_dir() -> Path:
+    """Return the analyzer's actual cache base directory."""
+    return Path(__file__).parent.parent / "clang_index_mcp" / ".mcp_cache"
+
+
 # ============================================================================
 # Session-scoped Fixtures (Created once per test session)
 # ============================================================================
@@ -62,6 +67,32 @@ def session_temp_dir():
     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_cache_dirs_session():
+    """
+    Session-level safety net: remove any cache dirs left behind after the suite.
+
+    Per-test cleanup handles most cases, but module-scoped fixtures and tests
+    run outside the pytest fixture lifecycle can leave directories behind.
+    This fixture captures the initial state of clang_index_mcp/.mcp_cache at
+    session start and removes any directories that appear by session end.
+    """
+    cache_base = _cache_base_dir()
+    initial_cache_dirs = set(cache_base.iterdir()) if cache_base.exists() else set()
+
+    yield
+
+    if not cache_base.exists():
+        return
+
+    for cache_dir in cache_base.iterdir():
+        if cache_dir not in initial_cache_dirs:
+            try:
+                shutil.rmtree(cache_dir, ignore_errors=True)
+            except Exception:
+                pass  # Best-effort cleanup
+
+
 # ============================================================================
 # Function-scoped Fixtures (Created for each test function)
 # ============================================================================
@@ -76,12 +107,11 @@ def cleanup_cache_dirs(request):
     .mcp_cache/ directories created during tests are properly cleaned up,
     preventing cache pollution between tests.
     """
-    # Get initial set of cache dirs before test runs
-    project_root = Path(__file__).parent.parent
-    cache_base = project_root / ".mcp_cache"
-    initial_cache_dirs = set()
-    if cache_base.exists():
-        initial_cache_dirs = set(cache_base.iterdir())
+    # Get initial set of cache dirs before test runs.
+    # The analyzer stores caches under the clang_index_mcp package root,
+    # not the repository root, so point at the actual cache base.
+    cache_base = _cache_base_dir()
+    initial_cache_dirs = set(cache_base.iterdir()) if cache_base.exists() else set()
 
     # Run the test
     yield
@@ -181,14 +211,9 @@ def analyzer(temp_project_dir):
     yield analyzer_instance
     # Close analyzer and clean up cache
     if hasattr(analyzer_instance, "cache_manager"):
+        cache_dir = analyzer_instance.cache_manager.cache_dir
         analyzer_instance.cache_manager.close()
-    # Clean up cache directory
-    project_root = Path(__file__).parent.parent
-    cache_base = project_root / ".mcp_cache"
-    if cache_base.exists():
-        # Clean up all cache directories related to this temp project
-        project_name = Path(temp_project_dir).name
-        for cache_dir in cache_base.glob(f"{project_name}_*"):
+        if cache_dir.exists():
             shutil.rmtree(cache_dir, ignore_errors=True)
 
 
@@ -250,14 +275,9 @@ void globalFunction();
     yield analyzer_instance
     # Close analyzer and clean up cache
     if hasattr(analyzer_instance, "cache_manager"):
+        cache_dir = analyzer_instance.cache_manager.cache_dir
         analyzer_instance.cache_manager.close()
-    # Clean up cache directory
-    project_root = Path(__file__).parent.parent
-    cache_base = project_root / ".mcp_cache"
-    if cache_base.exists():
-        # Clean up all cache directories related to this temp project
-        project_name = Path(temp_project_dir).name
-        for cache_dir in cache_base.glob(f"{project_name}_*"):
+        if cache_dir.exists():
             shutil.rmtree(cache_dir, ignore_errors=True)
 
 

--- a/tests/test_compile_commands_cache_location.py
+++ b/tests/test_compile_commands_cache_location.py
@@ -1,6 +1,7 @@
 """Test script to verify compile_commands cache works with multiple builds."""
 
 import json
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -112,6 +113,15 @@ def test_multiple_builds():
         print("\n✅ SUCCESS: Different builds get different compile_commands caches!")
         print(f"   Debug uses:   {debug_cc_cache.name}")
         print(f"   Release uses: {release_cc_cache.name}")
+
+        # Clean up analyzer caches so running this script standalone doesn't
+        # leave directories behind in clang_index_mcp/.mcp_cache.
+        for an in (debug_analyzer, release_analyzer):
+            if hasattr(an, "cache_manager"):
+                cache_dir = an.cache_manager.cache_dir
+                an.cache_manager.close()
+                if cache_dir.exists():
+                    shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_get_class_hierarchy.py
+++ b/tests/test_get_class_hierarchy.py
@@ -67,7 +67,10 @@ def analyzer(tmp_path_factory):
     yield a
 
     if hasattr(a, "cache_manager"):
+        cache_dir = a.cache_manager.cache_dir
         a.cache_manager.close()
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 # =============================================================================

--- a/tests/test_inheritance_comprehensive.py
+++ b/tests/test_inheritance_comprehensive.py
@@ -69,7 +69,10 @@ def analyzer(tmp_path_factory):
     yield a
 
     if hasattr(a, "cache_manager"):
+        cache_dir = a.cache_manager.cache_dir
         a.cache_manager.close()
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 # =============================================================================

--- a/tests/test_out_of_line_methods.py
+++ b/tests/test_out_of_line_methods.py
@@ -10,6 +10,7 @@ resolved via semantic_parent or qualified_name prefix matching.
 """
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -121,7 +122,10 @@ def analyzer(tmp_path_factory):
     yield a
 
     if hasattr(a, "cache_manager"):
+        cache_dir = a.cache_manager.cache_dir
         a.cache_manager.close()
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 # =============================================================================

--- a/tests/test_template_support.py
+++ b/tests/test_template_support.py
@@ -44,7 +44,14 @@ def analyzer(template_project_path):
     """Create and index template test project."""
     analyzer = CppAnalyzer(project_root=str(template_project_path))
     analyzer.index_project(force=True)
-    return analyzer
+    try:
+        yield analyzer
+    finally:
+        if hasattr(analyzer, "cache_manager"):
+            cache_dir = analyzer.cache_manager.cache_dir
+            analyzer.cache_manager.close()
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 class TestTemplateIndexing:
@@ -1066,7 +1073,14 @@ def param_inheritance_analyzer(param_inheritance_project):
     """Create and index parameter inheritance test project."""
     analyzer = CppAnalyzer(project_root=str(param_inheritance_project))
     analyzer.index_project(force=True)
-    return analyzer
+    try:
+        yield analyzer
+    finally:
+        if hasattr(analyzer, "cache_manager"):
+            cache_dir = analyzer.cache_manager.cache_dir
+            analyzer.cache_manager.close()
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 class TestTemplateBaseClassImprovement:
@@ -1323,7 +1337,14 @@ def embedded_type_param_analyzer(embedded_type_param_project):
     """Create and index embedded type-parameter test project."""
     analyzer = CppAnalyzer(project_root=str(embedded_type_param_project))
     analyzer.index_project(force=True)
-    return analyzer
+    try:
+        yield analyzer
+    finally:
+        if hasattr(analyzer, "cache_manager"):
+            cache_dir = analyzer.cache_manager.cache_dir
+            analyzer.cache_manager.close()
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 class TestEmbeddedTypeParameterSubstitution:


### PR DESCRIPTION
## Summary

The analyzer stores project caches under `clang_index_mcp/.mcp_cache`, but the shared test cleanup fixture was pointing at the repository root `.mcp_cache` and missed directories. This left hundreds of cache directories behind after running the test suite.

## Changes

- Fix the autouse per-test cleanup fixture to use the actual cache base (`clang_index_mcp/.mcp_cache`).
- Add a session-scoped safety net that removes any cache directories created during the test session.
- Update analyzer fixtures to close cache managers and remove their cache dirs on teardown.
- Add explicit cleanup to `test_compile_commands_cache_location.py` for standalone runs.

## Verification

- `make test`: 1455 passed, 17 skipped, 4 xpassed
- `make check`: passed
- `clang_index_mcp/.mcp_cache` is empty after running the full suite