### PR TITLE
docs: note long-running test suite for AI assistants

### DIFF
--- a/.ai/CLAUDE.md
+++ b/.ai/CLAUDE.md
@@ -53,6 +53,8 @@ pytest tests/test_compile_commands_manager.py::test_specific
 pytest -v -s                    # Verbose with print statements
 ```
 
+> **Note for AI assistants:** `make test` runs the full pytest suite. Its duration is host-dependent and can be long enough to exceed default command/tool timeouts. Run it as a background task if needed, and consult the local agent memory for host-specific timeout and agent-harness instructions.
+
 ### Code Quality
 ```bash
 make lint                       # Run flake8 (max-line-length=100)


### PR DESCRIPTION
## Description

Adds a note to `.ai/CLAUDE.md` reminding AI assistants that `make test` runs the full pytest suite, which is host-dependent and can exceed default command/tool timeouts.

## Type of Change

- [x] Documentation update

## Changes Made

- Updated the Testing section in `.ai/CLAUDE.md` to describe the host-dependent duration of `make test`.
- Removed any concrete duration/timeout values; instead, the note points to local agent memory for host-specific timeout and agent-harness instructions.

## Testing

- This is a documentation-only change; no functional code was modified.
- Existing code quality and test suite validation was performed in the preceding branch work.

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings