### PR TITLE
Skip pre-push checks when pushing only ref deletions

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -73,6 +73,7 @@ git config core.hooksPath .githooks
 - Alternatively, `pre-commit run` (supported)
 
 **Pre-push hook** (full validation, runs before push):
+- Skipped when the push only deletes remote refs (e.g. `git push --delete origin branch`)
 - `make test` (blocking)
 - `make format-check` (blocking)
 - `make lint` (blocking)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -35,6 +35,23 @@ elif [ -f "mcp_env/Scripts/activate" ]; then
     . mcp_env/Scripts/activate
 fi
 
+# Skip checks when pushing only ref deletions. Git passes each proposed ref on
+# stdin as: <local_ref> <local_sha1> <remote_ref> <remote_sha1>. For deletions,
+# <local_ref> is the literal string "(delete)".
+delete_count=0
+ref_count=0
+while read -r local_ref _ _ _; do
+    ref_count=$((ref_count + 1))
+    if [ "$local_ref" = "(delete)" ]; then
+        delete_count=$((delete_count + 1))
+    fi
+done
+
+if [ "$ref_count" -gt 0 ] && [ "$ref_count" -eq "$delete_count" ]; then
+    echo -e "${GREEN}Push only deletes remote refs; skipping pre-push checks.${NC}"
+    exit 0
+fi
+
 # Check that pytest is available
 if ! python3 -m pytest --version >/dev/null 2>&1; then
     echo -e "${RED}ERROR: pytest not found. Install dev dependencies:${NC}"


### PR DESCRIPTION
Updates the `.githooks/pre-push` hook to skip the long validation run when every pushed ref is a remote deletion.

For `git push --delete origin <branch>`, Git passes each ref on stdin with the local ref set to the literal string `(delete)`. The hook now detects this case and exits successfully before running `make test`, `make format-check`, `make lint`, and `make type-check`.

Also updates `AGENTS.md` to document the behavior.