### PR TITLE
speedup test suite

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -160,6 +160,7 @@ Treat the following behaviors as critical unless the task explicitly requires ch
   - `MCP_DEBUG=1` for verbose logging.
   - `PYTHONUNBUFFERED=1` for unbuffered output.
   - `LIBCLANG_PATH=/path/to/libclang.so` to override libclang discovery.
+  - `MCP_CACHE_BASE_DIR=/path/to/cache` to override the parent directory for all project caches (useful for test/CI isolation).
 
 ## Change Guidelines
 

--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -32,7 +32,8 @@ python scripts/test_installation.py
 Primary validation commands:
 
 ```bash
-make test
+make test-fast   # preferred: parallel-safe tests + serial tests
+make test        # sequential fallback (slower, used for coverage/debugging)
 make check
 make lint
 make format
@@ -51,7 +52,8 @@ make dev
 ## Testing Constraints
 
 - Never run multiple `pytest` processes at the same time in this repository. The SQLite cache can conflict across concurrent test runs.
-- If code changes touch analyzer behavior, prefer running `make test`.
+- `make test-fast` is safe to use: it runs one xdist invocation followed by one sequential invocation, never two pytest processes concurrently.
+- If code changes touch analyzer behavior, prefer running `make test-fast` (or `make test` if you need the slower sequential/coverage run).
 - If code changes affect formatting, linting, or typing expectations, run the relevant `make` target or `make check`.
 - If you could not run the appropriate validation, say so explicitly in the final response.
 
@@ -74,7 +76,7 @@ git config core.hooksPath .githooks
 
 **Pre-push hook** (full validation, runs before push):
 - Skipped when the push only deletes remote refs (e.g. `git push --delete origin branch`)
-- `make test` (blocking)
+- `make test-fast` (blocking)
 - `make format-check` (blocking)
 - `make lint` (blocking)
 - `make type-check` (informational)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -38,9 +38,19 @@ fi
 # Skip checks when pushing only ref deletions. Git passes each proposed ref on
 # stdin as: <local_ref> <local_sha1> <remote_ref> <remote_sha1>. For deletions,
 # <local_ref> is the literal string "(delete)".
+#
+# Use a short read timeout so the hook does not hang in agentic/non-interactive
+# environments that do not forward or close stdin for the pre-push hook.
 delete_count=0
 ref_count=0
-while read -r local_ref _ _ _; do
+while true; do
+    local_ref=""
+    if ! IFS= read -r -t 2 local_ref _ _ _; then
+        break
+    fi
+    if [ -z "$local_ref" ]; then
+        continue
+    fi
     ref_count=$((ref_count + 1))
     if [ "$local_ref" = "(delete)" ]; then
         delete_count=$((delete_count + 1))
@@ -51,6 +61,11 @@ if [ "$ref_count" -gt 0 ] && [ "$ref_count" -eq "$delete_count" ]; then
     echo -e "${GREEN}Push only deletes remote refs; skipping pre-push checks.${NC}"
     exit 0
 fi
+
+# Detach stdin before running the test suite. pytest-xdist inherits the Git
+# stdin pipe and can deadlock while waiting for it to close; redirecting stdin
+# to /dev/null avoids that.
+exec 0</dev/null
 
 # Check that pytest is available
 if ! python3 -m pytest --version >/dev/null 2>&1; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,7 +4,7 @@
 # before allowing push to remote.
 #
 # Enforced (blocks push on failure):
-#   - make test        (pytest suite)
+#   - make test-fast   (pytest suite, parallel-safe + serial stages)
 #   - make format-check (black formatting)
 #   - make lint        (flake8)
 #   - make type-check  (mypy)
@@ -63,8 +63,8 @@ fi
 # === ENFORCED CHECKS (block push on failure) ===
 
 # Run tests
-echo -e "${YELLOW}Running tests (make test)...${NC}"
-if make test; then
+echo -e "${YELLOW}Running tests (make test-fast)...${NC}"
+if make test-fast; then
     echo -e "${GREEN}Tests passed!${NC}"
 else
     echo -e "${RED}Tests FAILED. Push aborted.${NC}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           pip install .[dev]
 
       - name: Run tests
-        run: make test
+        run: make test-fast
 
   build:
     name: Build Package

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -258,11 +258,17 @@ This is documented in detail in the "Configuration File Locations" section above
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `CLANG_INDEX_CACHE_DIR` | string | `.mcp_cache` | Custom cache directory location |
+| `MCP_CACHE_BASE_DIR` | string | (none) | Override the parent directory for all project caches |
 
 **CLANG_INDEX_CACHE_DIR**:
 - **Default**: `.mcp_cache` (relative to MCP server root)
 - **Use Case**: Custom cache location (e.g., faster SSD, network storage)
 - **Note**: Cache location must be on a local filesystem (not NFS)
+
+**MCP_CACHE_BASE_DIR**:
+- **Default**: unset (cache directories are placed under the configured cache location)
+- **Use Case**: Run multiple isolated analyzer instances or parallel test workers against separate cache roots without changing the per-project cache naming.
+- **Note**: This overrides the *base* directory; per-project subdirectories are still created underneath it.
 
 **Example**:
 ```bash

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -257,7 +257,7 @@ This is documented in detail in the "Configuration File Locations" section above
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `CLANG_INDEX_CACHE_DIR` | string | `.mcp_cache` | Custom cache directory location |
+| `CLANG_INDEX_CACHE_DIR` | string | `.mcp_cache` | Custom cache directory location (legacy/user-facing alias) |
 | `MCP_CACHE_BASE_DIR` | string | (none) | Override the parent directory for all project caches |
 
 **CLANG_INDEX_CACHE_DIR**:
@@ -266,9 +266,9 @@ This is documented in detail in the "Configuration File Locations" section above
 - **Note**: Cache location must be on a local filesystem (not NFS)
 
 **MCP_CACHE_BASE_DIR**:
-- **Default**: unset (cache directories are placed under the configured cache location)
+- **Default**: unset (falls back to `CLANG_INDEX_CACHE_DIR`, then to the default `.mcp_cache`)
 - **Use Case**: Run multiple isolated analyzer instances or parallel test workers against separate cache roots without changing the per-project cache naming.
-- **Note**: This overrides the *base* directory; per-project subdirectories are still created underneath it.
+- **Note**: This overrides the *base* directory; per-project subdirectories are still created underneath it. If both variables are set, `MCP_CACHE_BASE_DIR` wins.
 
 **Example**:
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,9 @@ test: ## Run all tests
 
 test-fast: ## Run tests in parallel where safe, then serial tests
 	@echo "$(BLUE)Running tests in parallel mode...$(NC)"
-	$(PYTHON) -m pytest -q -n auto -m "not serial" --no-cov -p no:cacheprovider
+	$(PYTHON) -m pytest -q -n auto -m "not serial" --no-cov -p no:cacheprovider --capture=no
 	@echo "$(BLUE)Running serial tests...$(NC)"
-	$(PYTHON) -m pytest -q -m "serial" --no-cov -p no:cacheprovider
+	$(PYTHON) -m pytest -q -m "serial" --no-cov -p no:cacheprovider --capture=no
 	@echo "$(GREEN)Tests complete!$(NC)"
 
 test-coverage: ## Run tests with coverage report

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup clean test test-coverage lint format check install run dev
+.PHONY: help setup clean test test-fast test-coverage lint format check install run dev
 
 # Detect operating system
 ifeq ($(OS),Windows_NT)
@@ -70,6 +70,13 @@ install-editable: ## Install package in editable mode for development
 test: ## Run all tests
 	@echo "$(BLUE)Running tests...$(NC)"
 	$(PYTHON) -m pytest -v
+	@echo "$(GREEN)Tests complete!$(NC)"
+
+test-fast: ## Run tests in parallel where safe, then serial tests
+	@echo "$(BLUE)Running tests in parallel mode...$(NC)"
+	$(PYTHON) -m pytest -q -n auto -m "not serial" --no-cov -p no:cacheprovider
+	@echo "$(BLUE)Running serial tests...$(NC)"
+	$(PYTHON) -m pytest -q -m "serial" --no-cov -p no:cacheprovider
 	@echo "$(GREEN)Tests complete!$(NC)"
 
 test-coverage: ## Run tests with coverage report

--- a/clang_index_mcp/_persistence/cache_manager.py
+++ b/clang_index_mcp/_persistence/cache_manager.py
@@ -87,7 +87,9 @@ class CacheManager:
         """Compute the cache directory for a project identity."""
         import os
 
-        env_base = os.environ.get("MCP_CACHE_BASE_DIR")
+        # MCP_CACHE_BASE_DIR takes precedence; CLANG_INDEX_CACHE_DIR is the
+        # legacy/user-facing alias and is honored when the newer variable is unset.
+        env_base = os.environ.get("MCP_CACHE_BASE_DIR") or os.environ.get("CLANG_INDEX_CACHE_DIR")
         if env_base:
             cache_base = Path(env_base)
         else:

--- a/clang_index_mcp/_persistence/cache_manager.py
+++ b/clang_index_mcp/_persistence/cache_manager.py
@@ -85,10 +85,16 @@ class CacheManager:
     @staticmethod
     def compute_cache_dir(project_identity: ProjectIdentity) -> Path:
         """Compute the cache directory for a project identity."""
-        clang_index_mcp_root = Path(
-            __file__
-        ).parent.parent  # Go up from cache_manager.py to package root
-        cache_base = clang_index_mcp_root / ".mcp_cache"
+        import os
+
+        env_base = os.environ.get("MCP_CACHE_BASE_DIR")
+        if env_base:
+            cache_base = Path(env_base)
+        else:
+            clang_index_mcp_root = Path(
+                __file__
+            ).parent.parent  # Go up from cache_manager.py to package root
+            cache_base = clang_index_mcp_root / ".mcp_cache"
         cache_dir_name = project_identity.get_cache_directory_name()
         return cache_base / cache_dir_name
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -46,6 +46,7 @@ filterwarnings =
 markers =
     # Test speed
     slow: marks tests as slow (deselect with '-m "not slow"')
+    serial: marks tests that must run sequentially (not parallelizable)
 
     # Test types
     integration: marks tests as integration tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,27 @@ from tests.utils.test_helpers import (
     temp_project,
 )
 
+
 def _cache_base_dir() -> Path:
     """Return the analyzer's actual cache base directory."""
-    return Path(__file__).parent.parent / "clang_index_mcp" / ".mcp_cache"
+    env_base = os.environ.get("MCP_CACHE_BASE_DIR")
+    if env_base:
+        base = Path(env_base)
+    else:
+        base = Path(__file__).parent.parent / "clang_index_mcp" / ".mcp_cache"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+# Isolate caches per pytest-xdist worker. Spawned analyzer worker processes
+# inherit the environment variable, so they write to the same worker-private base.
+# The base name keeps the '.mcp_cache' substring so tests that assert on the path
+# continue to pass.
+_xdist_worker = os.environ.get("PYTEST_XDIST_WORKER_ID") or os.environ.get("PYTEST_XDIST_WORKER")
+if _xdist_worker and "MCP_CACHE_BASE_DIR" not in os.environ:
+    os.environ["MCP_CACHE_BASE_DIR"] = str(
+        Path(tempfile.gettempdir()) / f".mcp_cache_{_xdist_worker}"
+    )
 
 
 # ============================================================================

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -245,6 +245,7 @@ void func5() { func4(); func3(); }
 
 @pytest.mark.slow
 @pytest.mark.benchmark
+@pytest.mark.serial
 class TestCacheBenchmarks:
     """Benchmarks for cache backend performance"""
 

--- a/tests/test_call_sites_extraction.py
+++ b/tests/test_call_sites_extraction.py
@@ -13,6 +13,7 @@ Tests call site tracking with line-level precision, covering:
 """
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -24,19 +25,32 @@ from clang_index_mcp.cpp_analyzer import CppAnalyzer
 from clang_index_mcp._mcp.state_manager import AnalyzerState, AnalyzerStateManager
 
 
-@pytest.fixture
-def phase3_fixtures_dir(tmp_path):
-    """Get path to Phase 3 test fixtures."""
+@pytest.fixture(scope="module")
+def phase3_fixtures_dir(tmp_path_factory):
+    """Copy Phase 3 test fixtures to a module-private temp directory."""
     fixtures_path = Path(__file__).parent / "fixtures" / "phase3_samples"
-    return fixtures_path
+    project_path = tmp_path_factory.mktemp("phase3_samples")
+    for item in fixtures_path.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, project_path / item.name)
+        else:
+            shutil.copy2(item, project_path / item.name)
+    return project_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def analyzer(phase3_fixtures_dir):
-    """Create a fresh analyzer instance for testing."""
-    # CppAnalyzer takes project directory, not cache_dir
+    """Create and index a module-scoped analyzer for the Phase 3 fixtures."""
     analyzer = CppAnalyzer(str(phase3_fixtures_dir))
-    return analyzer
+    analyzer.index_project()
+    try:
+        yield analyzer
+    finally:
+        if hasattr(analyzer, "cache_manager"):
+            cache_dir = analyzer.cache_manager.cache_dir
+            analyzer.cache_manager.close()
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 class TestBasicCallSiteExtraction:

--- a/tests/test_concurrent_queries_during_indexing.py
+++ b/tests/test_concurrent_queries_during_indexing.py
@@ -472,6 +472,7 @@ def test_no_runtime_error_during_concurrent_search(large_cpp_project):
             pytest.fail(f"Unexpected error during {source}: {err}")
 
 
+@pytest.mark.serial
 def test_lock_performance_impact_is_minimal(large_cpp_project):
     """
     Test that adding index_lock does not significantly slow down queries

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -61,15 +61,20 @@ async def http_server():
 
     # Poll the root endpoint until the server is ready
     base_url = f"http://{TEST_HOST}:{port}"
+    ready = False
     async with httpx.AsyncClient() as client:
-        for _ in range(50):
+        for _ in range(60):
             try:
-                response = await client.get(base_url, timeout=0.1)
+                response = await client.get(base_url, timeout=0.5)
                 if response.status_code == 200:
+                    ready = True
                     break
-            except (httpx.ConnectError, httpx.NetworkError):
+            except (httpx.ConnectError, httpx.NetworkError, httpx.TimeoutException):
                 pass
             await asyncio.sleep(0.05)
+
+    if not ready:
+        pytest.fail(f"HTTP server failed to start on {base_url}")
 
     yield base_url
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -59,11 +59,17 @@ async def http_server():
     # Start server in background task
     server_task = asyncio.create_task(http_srv.start())
 
-    # Wait a bit for server to start
-    await asyncio.sleep(1.5)
-
-    # Yield base URL for tests
+    # Poll the root endpoint until the server is ready
     base_url = f"http://{TEST_HOST}:{port}"
+    async with httpx.AsyncClient() as client:
+        for _ in range(50):
+            try:
+                response = await client.get(base_url, timeout=0.1)
+                if response.status_code == 200:
+                    break
+            except (httpx.ConnectError, httpx.NetworkError):
+                pass
+            await asyncio.sleep(0.05)
 
     yield base_url
 
@@ -74,9 +80,6 @@ async def http_server():
         await server_task
     except asyncio.CancelledError:
         pass
-
-    # Give time for port to be released and sockets to close
-    await asyncio.sleep(1.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_macro_type_alias.py
+++ b/tests/test_macro_type_alias.py
@@ -19,30 +19,34 @@ import pytest
 from clang_index_mcp.cpp_analyzer import CppAnalyzer
 
 
+@pytest.fixture(scope="module")
+def macro_alias_project(tmp_path_factory):
+    """Create a module-scoped test project with macro-generated type aliases."""
+    tmp_path = tmp_path_factory.mktemp("macro_alias")
+    fixture_dir = os.path.join(os.path.dirname(__file__), "fixtures", "macro_alias")
+
+    # Copy all files
+    for filename in os.listdir(fixture_dir):
+        src = os.path.join(fixture_dir, filename)
+        dst = os.path.join(tmp_path, filename)
+        shutil.copy2(src, dst)
+
+    return str(tmp_path)
+
+
+@pytest.fixture(scope="module")
+def analyzer(macro_alias_project):
+    """Create and initialize a module-scoped analyzer for the test project."""
+    analyzer = CppAnalyzer(macro_alias_project)
+    analyzer.index_project()
+    try:
+        yield analyzer
+    finally:
+        analyzer.close()
+
+
 class TestMacroTypeAlias:
     """Test suite for macro-generated type alias indexing."""
-
-    @pytest.fixture
-    def macro_alias_project(self, tmp_path):
-        """Create a test project with macro-generated type aliases."""
-        # Copy the macro_alias fixtures to temp directory
-        fixture_dir = os.path.join(os.path.dirname(__file__), "fixtures", "macro_alias")
-
-        # Copy all files
-        for filename in os.listdir(fixture_dir):
-            src = os.path.join(fixture_dir, filename)
-            dst = os.path.join(tmp_path, filename)
-            shutil.copy2(src, dst)
-
-        return str(tmp_path)
-
-    @pytest.fixture
-    def analyzer(self, macro_alias_project):
-        """Create and initialize analyzer for the test project."""
-        analyzer = CppAnalyzer(macro_alias_project)
-        analyzer.index_project()
-        yield analyzer
-        analyzer.close()
 
     def test_macro_type_alias_indexed(self, analyzer):
         """Test that macro-expanded type aliases are indexed."""
@@ -120,24 +124,6 @@ class TestMacroTypeAlias:
 
 class TestMacroTypeAliasDebug:
     """Debug tests to understand the issue."""
-
-    @pytest.fixture
-    def macro_alias_project(self, tmp_path):
-        """Create a test project with macro-generated type aliases."""
-        fixture_dir = os.path.join(os.path.dirname(__file__), "fixtures", "macro_alias")
-        for filename in os.listdir(fixture_dir):
-            src = os.path.join(fixture_dir, filename)
-            dst = os.path.join(tmp_path, filename)
-            shutil.copy2(src, dst)
-        return str(tmp_path)
-
-    @pytest.fixture
-    def analyzer(self, macro_alias_project):
-        """Create and initialize analyzer for the test project."""
-        analyzer = CppAnalyzer(macro_alias_project)
-        analyzer.index_project()
-        yield analyzer
-        analyzer.close()
 
     def test_debug_all_indexed_aliases(self, analyzer):
         """Debug: Print all indexed type aliases."""

--- a/tests/test_phase3_mcp_tools.py
+++ b/tests/test_phase3_mcp_tools.py
@@ -9,6 +9,7 @@ Tests the MCP tool layer to ensure proper integration with call site tracking:
 """
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -19,19 +20,32 @@ from clang_index_mcp.cpp_analyzer import CppAnalyzer
 from clang_index_mcp._mcp.state_manager import AnalyzerState, AnalyzerStateManager
 
 
-@pytest.fixture
-def phase3_fixtures_dir(tmp_path):
-    """Get path to Phase 3 test fixtures."""
+@pytest.fixture(scope="module")
+def phase3_fixtures_dir(tmp_path_factory):
+    """Copy Phase 3 test fixtures to a module-private temp directory."""
     fixtures_path = Path(__file__).parent / "fixtures" / "phase3_samples"
-    return fixtures_path
+    project_path = tmp_path_factory.mktemp("phase3_samples")
+    for item in fixtures_path.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, project_path / item.name)
+        else:
+            shutil.copy2(item, project_path / item.name)
+    return project_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def indexed_analyzer(phase3_fixtures_dir):
-    """Create and return a pre-indexed analyzer."""
+    """Create and return a module-scoped pre-indexed analyzer."""
     analyzer = CppAnalyzer(str(phase3_fixtures_dir))
     analyzer.index_project()
-    return analyzer
+    try:
+        yield analyzer
+    finally:
+        if hasattr(analyzer, "cache_manager"):
+            cache_dir = analyzer.cache_manager.cache_dir
+            analyzer.cache_manager.close()
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 class TestGetIncomingCallsToolIntegration:

--- a/tests/test_qualified_name_performance.py
+++ b/tests/test_qualified_name_performance.py
@@ -228,6 +228,7 @@ namespace ns{i} {{
 
             print(f"\n  Small project indexing: {elapsed*1000:.0f}ms ({len(results)} classes)")
 
+    @pytest.mark.serial
     def test_incremental_refresh_performance(self):
         """Incremental refresh should be faster than full reindex."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_qualified_name_performance.py
+++ b/tests/test_qualified_name_performance.py
@@ -16,6 +16,7 @@ Benchmarks cover:
 - Large dataset performance
 """
 
+import shutil
 import tempfile
 import time
 from pathlib import Path
@@ -29,17 +30,17 @@ from clang_index_mcp.cpp_analyzer import CppAnalyzer
 class TestQualifiedSearchPerformance:
     """Benchmark qualified pattern search performance."""
 
-    @pytest.fixture
-    def large_project(self):
-        """Create a large test project with many classes."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create test files with many classes in various namespaces
-            for i in range(50):  # 50 files
-                test_file = Path(tmpdir) / f"file{i}.cpp"
-                content = []
-                for j in range(20):  # 20 classes per file = 1000 total classes
-                    ns = f"ns{i % 10}"  # 10 different namespaces
-                    content.append(f"""
+    @pytest.fixture(scope="module")
+    def large_project(self, tmp_path_factory):
+        """Create a large test project with many classes once per module."""
+        tmpdir = tmp_path_factory.mktemp("large_project")
+        # Create test files with many classes in various namespaces
+        for i in range(50):  # 50 files
+            test_file = tmpdir / f"file{i}.cpp"
+            content = []
+            for j in range(20):  # 20 classes per file = 1000 total classes
+                ns = f"ns{i % 10}"  # 10 different namespaces
+                content.append(f"""
 namespace {ns} {{
     class Class{i}_{j} {{
     public:
@@ -48,11 +49,18 @@ namespace {ns} {{
     }};
 }}
 """)
-                test_file.write_text("\n".join(content))
+            test_file.write_text("\n".join(content))
 
-            analyzer = CppAnalyzer(tmpdir)
-            analyzer.index_project()
+        analyzer = CppAnalyzer(str(tmpdir))
+        analyzer.index_project()
+        try:
             yield analyzer
+        finally:
+            if hasattr(analyzer, "cache_manager"):
+                cache_dir = analyzer.cache_manager.cache_dir
+                analyzer.cache_manager.close()
+                if cache_dir.exists():
+                    shutil.rmtree(cache_dir, ignore_errors=True)
 
     def test_unqualified_search_performance(self, large_project):
         """Unqualified pattern search should complete quickly."""

--- a/tests/test_sse_transport.py
+++ b/tests/test_sse_transport.py
@@ -59,15 +59,20 @@ async def sse_server():
 
     # Poll the root endpoint until the server is ready
     base_url = f"http://{TEST_HOST}:{port}"
+    ready = False
     async with httpx.AsyncClient() as client:
-        for _ in range(50):
+        for _ in range(60):
             try:
-                response = await client.get(base_url, timeout=0.1)
+                response = await client.get(base_url, timeout=0.5)
                 if response.status_code == 200:
+                    ready = True
                     break
-            except (httpx.ConnectError, httpx.NetworkError):
+            except (httpx.ConnectError, httpx.NetworkError, httpx.TimeoutException):
                 pass
             await asyncio.sleep(0.05)
+
+    if not ready:
+        pytest.fail(f"SSE server failed to start on {base_url}")
 
     yield base_url
 

--- a/tests/test_sse_transport.py
+++ b/tests/test_sse_transport.py
@@ -57,11 +57,17 @@ async def sse_server():
     # Start server in background task
     server_task = asyncio.create_task(sse_srv.start())
 
-    # Wait a bit for server to start
-    await asyncio.sleep(1.5)
-
-    # Yield base URL for tests
+    # Poll the root endpoint until the server is ready
     base_url = f"http://{TEST_HOST}:{port}"
+    async with httpx.AsyncClient() as client:
+        for _ in range(50):
+            try:
+                response = await client.get(base_url, timeout=0.1)
+                if response.status_code == 200:
+                    break
+            except (httpx.ConnectError, httpx.NetworkError):
+                pass
+            await asyncio.sleep(0.05)
 
     yield base_url
 
@@ -72,9 +78,6 @@ async def sse_server():
         await server_task
     except asyncio.CancelledError:
         pass
-
-    # Give time for port to be released and sockets to close
-    await asyncio.sleep(1.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_template_param_inheritance.py
+++ b/tests/test_template_param_inheritance.py
@@ -6,6 +6,7 @@ Problem: When template<T> class Foo : public T, and class Bar : Foo<Base>,
          get_derived_classes("Base") should find Bar through indirect inheritance.
 """
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -14,18 +15,32 @@ from clang_index_mcp.cpp_analyzer import CppAnalyzer
 from clang_index_mcp._symbols.model import SymbolInfo, get_template_param_base_indices
 
 
-@pytest.fixture
-def template_param_project():
-    """Get path to template parameter inheritance fixtures."""
+@pytest.fixture(scope="module")
+def template_param_project(tmp_path_factory):
+    """Copy template parameter inheritance fixtures to a module-private temp directory."""
     fixtures_path = Path(__file__).parent / "fixtures" / "template_param_inheritance"
-    return fixtures_path
+    project_path = tmp_path_factory.mktemp("template_param_inheritance")
+    for item in fixtures_path.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, project_path / item.name)
+        else:
+            shutil.copy2(item, project_path / item.name)
+    return project_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def analyzer(template_param_project):
-    """Create a fresh analyzer instance for testing."""
+    """Create and index a module-scoped analyzer for testing."""
     analyzer = CppAnalyzer(str(template_param_project))
-    return analyzer
+    analyzer.index_project()
+    try:
+        yield analyzer
+    finally:
+        if hasattr(analyzer, "cache_manager"):
+            cache_dir = analyzer.cache_manager.cache_dir
+            analyzer.cache_manager.close()
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 class TestTemplateParamInheritanceTracking:
@@ -33,7 +48,6 @@ class TestTemplateParamInheritanceTracking:
 
     def test_template_param_indices_detection(self, analyzer):
         """Test that get_template_param_inheritance_indices correctly detects template param bases."""
-        analyzer.index_project()
 
         # TemplateInheritsParam should inherit from param 0 (T)
         indices = analyzer.get_template_param_inheritance_indices("ns::TemplateInheritsParam")
@@ -41,7 +55,6 @@ class TestTemplateParamInheritanceTracking:
 
     def test_template_multiple_bases_indices_detection(self, analyzer):
         """Test detection for templates with multiple bases including template param."""
-        analyzer.index_project()
 
         # TemplateMultipleBases inherits from T (param 0) and AnotherBase
         # Only T should be detected as template param base
@@ -56,7 +69,6 @@ class TestGetDerivedClassesWithTemplateParamInheritance:
 
     def test_direct_inheritance_still_works(self, analyzer):
         """Verify direct inheritance detection still works."""
-        analyzer.index_project()
 
         # DirectDerived directly inherits from BaseClass
         derived = analyzer.get_derived_classes("BaseClass", project_only=False)
@@ -68,7 +80,6 @@ class TestGetDerivedClassesWithTemplateParamInheritance:
 
     def test_indirect_inheritance_through_template_param(self, analyzer):
         """Test that classes inheriting via template param are found."""
-        analyzer.index_project()
 
         # DerivedFromTemplate inherits from TemplateInheritsParam<BaseClass>
         # Since TemplateInheritsParam<T> : public T, this means
@@ -82,7 +93,6 @@ class TestGetDerivedClassesWithTemplateParamInheritance:
 
     def test_indirect_inheritance_with_multiple_bases(self, analyzer):
         """Test template with multiple bases including template param."""
-        analyzer.index_project()
 
         # DerivedFromTemplateMulti inherits from TemplateMultipleBases<BaseClass>
         # TemplateMultipleBases<T> : public T, public AnotherBase
@@ -96,7 +106,6 @@ class TestGetDerivedClassesWithTemplateParamInheritance:
 
     def test_unrelated_class_not_included(self, analyzer):
         """Verify unrelated classes are not included."""
-        analyzer.index_project()
 
         derived = analyzer.get_derived_classes("BaseClass", project_only=False)
         derived_names = [d["qualified_name"].split("::")[-1] for d in derived]
@@ -107,7 +116,6 @@ class TestGetDerivedClassesWithTemplateParamInheritance:
 
     def test_qualified_name_search(self, analyzer):
         """Test with qualified class name."""
-        analyzer.index_project()
 
         # Search using qualified name
         derived = analyzer.get_derived_classes("ns::BaseClass", project_only=False)
@@ -159,7 +167,6 @@ class TestCheckTemplateParamInheritance:
     def test_unknown_template_returns_false(self, analyzer):
         """Test that unknown template returns False."""
         # Need to index first to populate template_param_bases
-        analyzer.index_project()
         result = analyzer.check_template_param_inheritance(
             "UnknownTemplate<SomeClass>", "SomeClass"
         )
@@ -167,7 +174,6 @@ class TestCheckTemplateParamInheritance:
 
     def test_matching_template_arg(self, analyzer):
         """Test matching when template arg equals target."""
-        analyzer.index_project()
 
         # After indexing, TemplateInheritsParam should be in template_param_bases
         # So TemplateInheritsParam<BaseClass> should inherit from BaseClass
@@ -178,7 +184,6 @@ class TestCheckTemplateParamInheritance:
 
     def test_simple_name_match(self, analyzer):
         """Test matching with simple names."""
-        analyzer.index_project()
 
         # Should match even with different qualification
         result = analyzer.check_template_param_inheritance(
@@ -198,7 +203,6 @@ class TestTemplateParamNameCollision:
 
     def test_template_param_not_false_positive_in_derived(self, analyzer):
         """template<typename Base> class Adapter : Base should NOT be derived from struct Base."""
-        analyzer.index_project()
 
         derived = analyzer.get_derived_classes("Base", project_only=False)
         derived_names = [d["qualified_name"].split("::")[-1] for d in derived]
@@ -212,7 +216,6 @@ class TestTemplateParamNameCollision:
 
     def test_real_derivation_still_found_alongside_collision(self, analyzer):
         """RealDerivedFromBase actually derives from struct Base - must still be found."""
-        analyzer.index_project()
 
         derived = analyzer.get_derived_classes("Base", project_only=False)
         derived_names = [d["qualified_name"].split("::")[-1] for d in derived]
@@ -224,7 +227,6 @@ class TestTemplateParamNameCollision:
 
     def test_indirect_inheritance_still_works_with_collision(self, analyzer):
         """Indirect inheritance through template instantiation should still work."""
-        analyzer.index_project()
 
         # DerivedFromTemplate inherits from TemplateInheritsParam<BaseClass>
         # which inherits from its template param T=BaseClass
@@ -308,7 +310,6 @@ class TestGetTemplateParamBaseIndices:
 
     def test_get_class_info_has_template_param_base_indices(self, analyzer):
         """get_class_info() should include template_param_base_indices field."""
-        analyzer.index_project()
 
         info = analyzer.get_class_info("ns::Adapter")
         assert info is not None

--- a/tests/test_template_support.py
+++ b/tests/test_template_support.py
@@ -13,16 +13,21 @@ import pytest
 from clang_index_mcp.cpp_analyzer import CppAnalyzer
 
 
-@pytest.fixture
-def template_project_path(tmp_path):
-    """Copy template test project to a temp dir and generate compile_commands.json there.
+@pytest.fixture(scope="module")
+def template_project_path(tmp_path_factory):
+    """Copy template test project to a temp dir once per module.
 
     Writing into the fixture source directory would dirty the git working tree on every
-    test run, so we copy the sources to tmp_path instead.
+    test run, so we copy the sources to a temp dir instead and share the indexed result
+    across all tests in the module.
     """
     src_path = Path(__file__).parent / "fixtures/template_test_project"
-    project_path = tmp_path / "template_test_project"
-    shutil.copytree(src_path, project_path)
+    project_path = tmp_path_factory.mktemp("template_test_project")
+    for item in src_path.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, project_path / item.name)
+        else:
+            shutil.copy2(item, project_path / item.name)
 
     files = ["main.cpp", "templates.h", "advanced_templates.h", "namespaced_templates.h"]
     compile_commands = [
@@ -39,9 +44,9 @@ def template_project_path(tmp_path):
     return project_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def analyzer(template_project_path):
-    """Create and index template test project."""
+    """Create and index template test project once per module."""
     analyzer = CppAnalyzer(project_root=str(template_project_path))
     analyzer.index_project(force=True)
     try:
@@ -972,14 +977,15 @@ class TestSpecializationLinkingEdgeCases:
 # ============================================================================
 
 
-@pytest.fixture
-def param_inheritance_project(tmp_path):
+@pytest.fixture(scope="module")
+def param_inheritance_project(tmp_path_factory):
     """
-    Create a test project with templates that inherit from template parameters.
+    Create a test project with templates that inherit from template parameters once per module.
 
     This tests the improvement where base_classes shows 'ParamName' instead of
     'type-parameter-0-0', making output LLM-friendly.
     """
+    tmp_path = tmp_path_factory.mktemp("param_inheritance")
     # Create header with template inheriting from parameter
     header = tmp_path / "param_inheritance.h"
     header.write_text("""
@@ -1068,9 +1074,9 @@ int main() {
     return tmp_path
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def param_inheritance_analyzer(param_inheritance_project):
-    """Create and index parameter inheritance test project."""
+    """Create and index parameter inheritance test project once per module."""
     analyzer = CppAnalyzer(project_root=str(param_inheritance_project))
     analyzer.index_project(force=True)
     try:

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -16,6 +16,8 @@ import pytest
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+pytestmark = pytest.mark.serial
+
 
 class TestTransportSelection:
     """Test suite for transport selection via command-line arguments."""


### PR DESCRIPTION
- **Step 1: module-scope fixtures for repeated full-index projects (492.54s -> 251.79s, 1.96x)**
- **Step 2: isolate SQLite caches per pytest-xdist worker**
- **Step 3: mark non-parallelizable tests with @pytest.mark.serial**
- **Step 4: replace transport fixture sleeps with root-endpoint polling**
- **Step 5: add make test-fast target for split parallel/serial execution**
- **Step 6: adopt make test-fast in agent rules, pre-push hook, and CI**
- **Step 7: document MCP_CACHE_BASE_DIR environment variable**
- **Step 8: honor CLANG_INDEX_CACHE_DIR as fallback for MCP_CACHE_BASE_DIR**
