### PR TITLE
chore: remove obsolete .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ __pycache__/
 benchmark_results.jsonl
 build/
 dist/
-lib/**/libclang*
 mcp_env/
 clang_index_mcp/consolidated_tools.py.bak
 clang_index_mcp/libclang/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 
 !.claude/skills/
-!.mcp_cache/.gitkeep
 !.test-projects/README.md
 !.test-scenarios/*.yaml
 !.test-scenarios/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 *.egg-info/
 *.py[cod]
 .claude/
-.claude/skills/**/__pycache__/
 .idea/
 .kimi/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -15,17 +15,14 @@
 # Python build artifacts
 # Test projects (managed by /test-mcp skill)
 # Test results (optional - can be kept for history)
-# Tool definition backups (created by optimize.py)
 # Virtual environment
 *.egg-info/
 *.py[cod]
-.aider*
 .claude/
 .claude/skills/**/__pycache__/
 .idea/
 .kimi/
 .vscode/
-.mcp.json
 .mcp_cache/*
 clang_index_mcp/.mcp_cache/*
 .test-projects/
@@ -36,7 +33,6 @@ benchmark_results.jsonl
 build/
 dist/
 mcp_env/
-clang_index_mcp/consolidated_tools.py.bak
 clang_index_mcp/libclang/
 mock_test_results.json
 tests/pytest.log


### PR DESCRIPTION
## Summary

Remove obsolete and redundant ignore patterns from `.gitignore`:

- `lib/**/libclang*` — bundled libclang now lives in `clang_index_mcp/libclang/` (already covered by a dedicated entry).
- `.aider*`, `.mcp.json`, `clang_index_mcp/consolidated_tools.py.bak` — unused tool/config artifacts.
- `.claude/skills/**/__pycache__/` — redundant, covered by the global `__pycache__/` rule.
- `!.mcp_cache/.gitkeep` — the `.gitkeep` file no longer exists; `.mcp_cache/` is created dynamically.

## Verification

- `git check-ignore` confirms intended files are still ignored/tracked correctly.
- Pre-push checks (`make test-fast`, `make format-check`, `make lint`, `make type-check`) passed.

## Notes

- `.kimi/` is kept per request.
