### PR TITLE
perf: offload worker per-file cache writes to a background thread

### DIFF
--- a/clang_index_mcp/_incremental/worker_orchestrator.py
+++ b/clang_index_mcp/_incremental/worker_orchestrator.py
@@ -44,8 +44,21 @@ def process_future_result(
     cache_orchestrator = ctx.cache_orchestrator
     symbol_store = ctx.symbol_store
 
-    # ProcessPoolExecutor returns (file_path, success, was_cached, symbols, call_sites, processed_headers)
-    _, success, was_cached, symbols, call_sites, processed_headers = result
+    # ProcessPoolExecutor returns:
+    # (file_path, success, was_cached, symbols, call_sites, processed_headers,
+    #  file_hash, compile_args_hash, error_message, retry_count)
+    (
+        _,
+        success,
+        was_cached,
+        symbols,
+        call_sites,
+        processed_headers,
+        file_hash,
+        compile_args_hash,
+        error_message,
+        retry_count,
+    ) = result
 
     if success and symbols:
         merge_symbols(ctx, symbols)
@@ -64,8 +77,20 @@ def process_future_result(
         for header_path, header_hash in processed_headers.items():
             cache_orchestrator.mark_header_completed(header_path, header_hash)
 
-    file_hash = cache_orchestrator.get_file_hash(file_path)
     symbol_store.set_file_hash(file_path, file_hash)
+
+    # Persist per-file cache from the main process. Workers skip cache writes so
+    # that all SQLite writes are serialized through a single process.
+    if not was_cached:
+        cache_orchestrator.save_file_cache(
+            file_path,
+            symbols if success else [],
+            file_hash,
+            compile_args_hash,
+            success=success,
+            error_message=error_message,
+            retry_count=retry_count,
+        )
 
     return success, was_cached
 

--- a/clang_index_mcp/_indexing/indexing_orchestrator.py
+++ b/clang_index_mcp/_indexing/indexing_orchestrator.py
@@ -150,6 +150,7 @@ class ProjectIndexingOrchestrator:
         finally:
             self.execution.worker_pool.shutdown_nowait(name="Indexing")
 
+        self.worker_result_merger.flush_cache_writes()
         return self._finalize_indexing(
             indexed_count, len(files), start_time, is_terminal, cache_hits, failed_count
         )

--- a/clang_index_mcp/_indexing/indexing_pipeline.py
+++ b/clang_index_mcp/_indexing/indexing_pipeline.py
@@ -7,12 +7,26 @@ and cache persistence.
 """
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from clang.cindex import TranslationUnit
 
 from .._core import diagnostics
+
+
+@dataclass
+class IndexingResult:
+    """Result of indexing a single file, including data needed to persist cache."""
+
+    success: bool
+    was_cached: bool
+    file_hash: str = ""
+    compile_args_hash: str = ""
+    error_message: Optional[str] = None
+    retry_count: int = 0
+
 
 if TYPE_CHECKING:
     from .._compilation.clang_parser import ClangParser
@@ -54,11 +68,35 @@ class SingleFileIndexingPipeline:
         self.symbol_store = symbol_store
 
     def index_file(self, file_path: str, force: bool = False) -> tuple[bool, bool]:
-        """Index a single C++ file.
+        """Index a single C++ file and write cache locally.
+
+        This is the public API entry point. It persists the per-file cache
+        immediately in the calling process.
 
         Returns:
             (success, was_cached) - success indicates if indexing succeeded,
                                    was_cached indicates if it was loaded from cache
+        """
+        result = self.index_file_with_result(file_path, force=force, write_cache=True)
+        return result.success, result.was_cached
+
+    def index_file_with_result(
+        self, file_path: str, force: bool = False, write_cache: bool = True
+    ) -> IndexingResult:
+        """Index a single C++ file and return a structured result.
+
+        When *write_cache* is False, the caller is responsible for persisting
+        the per-file cache. This is used by worker processes so that all SQLite
+        writes can be serialized through the main process.
+
+        Args:
+            file_path: Path to the C++ source file.
+            force: Force re-indexing even if cache exists.
+            write_cache: If True, write the per-file cache before returning.
+
+        Returns:
+            IndexingResult with success status, cache metadata, and the data
+            required to persist the cache if write_cache is False.
         """
         file_path = os.path.abspath(file_path)
 
@@ -66,7 +104,7 @@ class SingleFileIndexingPipeline:
             error_msg = f"Source file does not exist: {file_path}"
             diagnostics.error(error_msg)
             self.cache_manager.log_parse_error(file_path, FileNotFoundError(error_msg), "", None, 0)
-            return (False, False)
+            return IndexingResult(success=False, was_cached=False)
 
         current_hash = self.cache_orchestrator.get_file_hash(file_path)
         args = self.compilation_env.get_compile_args_for_file(Path(file_path))
@@ -76,7 +114,12 @@ class SingleFileIndexingPipeline:
             file_path, current_hash, compile_args_hash, force
         )
         if cached is not None:
-            return cached  # type: ignore[no-any-return]
+            return IndexingResult(
+                success=cached[0],
+                was_cached=True,
+                file_hash=current_hash,
+                compile_args_hash=compile_args_hash,
+            )
 
         retry_count = self._compute_retry_count(file_path, current_hash, compile_args_hash, force)
 
@@ -87,19 +130,26 @@ class SingleFileIndexingPipeline:
                 self._handle_index_file_failure(
                     file_path, error_msg, args, current_hash, compile_args_hash, retry_count
                 )
-                return (False, False)
+                return IndexingResult(
+                    success=False,
+                    was_cached=False,
+                    file_hash=current_hash,
+                    compile_args_hash=compile_args_hash,
+                    error_message=error_msg[:200],
+                    retry_count=retry_count,
+                )
 
             cache_error_msg = self._handle_index_file_diagnostics(
                 file_path, tu, current_hash, compile_args_hash, retry_count
             )
 
             return self._finalize_index_success(
-                file_path, tu, current_hash, compile_args_hash, cache_error_msg
+                file_path, tu, current_hash, compile_args_hash, cache_error_msg, write_cache
             )
 
         except Exception as e:
             return self._finalize_index_failure(
-                file_path, e, current_hash, compile_args_hash, retry_count
+                file_path, e, current_hash, compile_args_hash, retry_count, write_cache
             )
 
     def _compute_retry_count(
@@ -125,7 +175,7 @@ class SingleFileIndexingPipeline:
         compile_args_hash: str,
         retry_count: int,
     ) -> None:
-        """Log failure and save to cache."""
+        """Log failure."""
         diagnostics.error(f"Failed to parse {file_path}")
         diagnostics.error(f"  Error: {error_msg}")
 
@@ -138,17 +188,6 @@ class SingleFileIndexingPipeline:
         parse_error = Exception(f"{error_msg}\nArgs: {args}")
         self.cache_manager.log_parse_error(
             file_path, parse_error, current_hash, compile_args_hash, retry_count
-        )
-
-        # Save failure to cache
-        self.cache_orchestrator.save_file_cache(
-            file_path,
-            [],
-            current_hash,
-            compile_args_hash,
-            success=False,
-            error_message=error_msg[:200],
-            retry_count=retry_count,
         )
 
     def _handle_index_file_diagnostics(
@@ -173,8 +212,9 @@ class SingleFileIndexingPipeline:
         current_hash: str,
         compile_args_hash: str,
         cache_error_msg: Optional[str],
-    ) -> tuple[bool, bool]:
-        """Clear old entries, process TU, collect symbols, and save to cache."""
+        write_cache: bool,
+    ) -> IndexingResult:
+        """Clear old entries, process TU, collect symbols, and optionally save to cache."""
         with self.symbol_store.index_lock:
             self.symbol_store.clear_file_index_entries(file_path)
 
@@ -192,16 +232,24 @@ class SingleFileIndexingPipeline:
 
             self.symbol_store.set_file_hash(file_path, current_hash)
 
-        self.cache_orchestrator.save_file_cache(
-            file_path,
-            collected_symbols,
-            current_hash,
-            compile_args_hash,
+        if write_cache:
+            self.cache_orchestrator.save_file_cache(
+                file_path,
+                collected_symbols,
+                current_hash,
+                compile_args_hash,
+                success=True,
+                error_message=cache_error_msg,
+                retry_count=0,
+            )
+        return IndexingResult(
             success=True,
+            was_cached=False,
+            file_hash=current_hash,
+            compile_args_hash=compile_args_hash,
             error_message=cache_error_msg,
             retry_count=0,
         )
-        return (True, False)
 
     def _finalize_index_failure(
         self,
@@ -210,20 +258,29 @@ class SingleFileIndexingPipeline:
         current_hash: str,
         compile_args_hash: str,
         retry_count: int,
-    ) -> tuple[bool, bool]:
-        """Log parse error and save failure state to cache."""
+        write_cache: bool,
+    ) -> IndexingResult:
+        """Log parse error and optionally save failure state to cache."""
         self.cache_manager.log_parse_error(
             file_path, error, current_hash, compile_args_hash, retry_count
         )
         error_msg = str(error)[:200]
-        self.cache_orchestrator.save_file_cache(
-            file_path,
-            [],
-            current_hash,
-            compile_args_hash,
+        if write_cache:
+            self.cache_orchestrator.save_file_cache(
+                file_path,
+                [],
+                current_hash,
+                compile_args_hash,
+                success=False,
+                error_message=error_msg,
+                retry_count=retry_count,
+            )
+        diagnostics.debug(f"Failed to parse {file_path}: {error_msg}")
+        return IndexingResult(
             success=False,
+            was_cached=False,
+            file_hash=current_hash,
+            compile_args_hash=compile_args_hash,
             error_message=error_msg,
             retry_count=retry_count,
         )
-        diagnostics.debug(f"Failed to parse {file_path}: {error_msg}")
-        return (False, False)

--- a/clang_index_mcp/_indexing/refresh_pipeline.py
+++ b/clang_index_mcp/_indexing/refresh_pipeline.py
@@ -103,6 +103,7 @@ class RefreshPipeline:
                 include_dependencies,
                 callbacks,
             )
+            self.worker_result_merger.flush_cache_writes()
         except KeyboardInterrupt:
             diagnostics.info("\nRefresh interrupted by user (Ctrl-C)")
             self.execution.worker_pool.shutdown(name="Refresh")

--- a/clang_index_mcp/_indexing/worker_pool.py
+++ b/clang_index_mcp/_indexing/worker_pool.py
@@ -100,14 +100,15 @@ def _process_file_worker(spec: IndexingTaskSpec):
     # Set precomputed compile args
     context.compilation_env.provided_compile_args = spec.compile_args
 
-    # Parse the file
-    success, was_cached = _worker_analyzer.index_file(spec.file_path, spec.force)
+    # Parse the file, but do not write cache here; the main process will
+    # serialize all per-file cache writes to avoid SQLite contention.
+    result = _worker_analyzer.index_file_with_result(spec.file_path, spec.force, write_cache=False)
 
     # Extract symbols from this file
     symbols: List[Any] = []
     call_sites: List[Any] = []
     processed_headers: Dict[str, str] = {}
-    if success:
+    if result.success:
         for fpath, file_symbols in context.symbol_store.iter_file_items():
             symbols.extend(file_symbols)
 
@@ -128,7 +129,18 @@ def _process_file_worker(spec: IndexingTaskSpec):
     except Exception:
         pass
 
-    return (spec.file_path, success, was_cached, symbols, call_sites, processed_headers)
+    return (
+        spec.file_path,
+        result.success,
+        result.was_cached,
+        symbols,
+        call_sites,
+        processed_headers,
+        result.file_hash,
+        result.compile_args_hash,
+        result.error_message,
+        result.retry_count,
+    )
 
 
 class WorkerPoolManager:

--- a/clang_index_mcp/_indexing/worker_result_merger.py
+++ b/clang_index_mcp/_indexing/worker_result_merger.py
@@ -38,8 +38,24 @@ class WorkerResultMerger:
         self.cache_orchestrator = cache_orchestrator
 
     def merge_worker_result(self, result: Tuple, file_path: str):
-        """Merge symbols and call sites from a worker process result."""
-        _, success, was_cached, symbols, call_sites, processed_headers = result
+        """Merge symbols and call sites from a worker process result.
+
+        Also persist the per-file cache from the main process. Workers no longer
+        write cache themselves, so all SQLite writes during indexing are
+        serialized through this path.
+        """
+        (
+            _,
+            success,
+            was_cached,
+            symbols,
+            call_sites,
+            processed_headers,
+            file_hash,
+            compile_args_hash,
+            error_message,
+            retry_count,
+        ) = result
 
         if success and symbols:
             with self.symbol_store.index_lock:
@@ -57,8 +73,21 @@ class WorkerResultMerger:
                 for header_path, header_hash in processed_headers.items():
                     self.cache_orchestrator.mark_header_completed(header_path, header_hash)
 
-            file_hash = self.cache_orchestrator.get_file_hash(file_path)
             self.symbol_store.set_file_hash(file_path, file_hash)
+
+        # Persist per-file cache from the main process. Workers deliberately skip
+        # this step so that all SQLite writes contend on a single writer instead
+        # of N worker processes.
+        if not was_cached:
+            self.cache_orchestrator.save_file_cache(
+                file_path,
+                symbols if success else [],
+                file_hash,
+                compile_args_hash,
+                success=success,
+                error_message=error_message,
+                retry_count=retry_count,
+            )
 
     def get_worker_result(self, future, file_path: str) -> Tuple[bool, bool]:
         """Get result from future and merge into indexes."""
@@ -72,8 +101,6 @@ class WorkerResultMerger:
 
     def process_refresh_result(self, file_path: str, res: Any) -> bool:
         """Process result from indexing worker during refresh. Returns True if successful."""
-        success = res[1]
-        if success:
-            self.merge_worker_result(res, file_path)
-            return True
-        return False
+        success = bool(res[1])
+        self.merge_worker_result(res, file_path)
+        return success

--- a/clang_index_mcp/_indexing/worker_result_merger.py
+++ b/clang_index_mcp/_indexing/worker_result_merger.py
@@ -6,7 +6,10 @@ and header-tracking state produced by worker processes back into the main proces
 indexes.
 """
 
-from typing import TYPE_CHECKING, Any, Tuple
+import queue
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from .._core import diagnostics
 
@@ -14,6 +17,19 @@ if TYPE_CHECKING:
     from .._persistence.cache_orchestrator import CacheOrchestrator
     from .._search.call_graph_service import CallGraphService
     from .._symbols.symbol_index_store import SymbolIndexStore
+
+
+@dataclass
+class _CacheWriteRequest:
+    """Per-file cache data handed off to the background writer thread."""
+
+    file_path: str
+    symbols: List[Any]
+    file_hash: str
+    compile_args_hash: Optional[str]
+    success: bool
+    error_message: Optional[str]
+    retry_count: int
 
 
 class WorkerResultMerger:
@@ -37,12 +53,128 @@ class WorkerResultMerger:
         self.call_graph_service = call_graph_service
         self.cache_orchestrator = cache_orchestrator
 
+        self._cache_queue: Optional[queue.SimpleQueue] = None
+        self._cache_writer_thread: Optional[threading.Thread] = None
+        self._cache_writer_lock = threading.Lock()
+
+    def _get_project_identity(self) -> Optional[Any]:
+        """Return the project identity used to open a private cache connection."""
+        cache_manager = getattr(self.cache_orchestrator, "cache_manager", None)
+        if cache_manager is None:
+            return None
+        return getattr(cache_manager, "project_identity", None)
+
+    def _ensure_cache_writer_started(self) -> None:
+        """Start the background cache writer thread on first use."""
+        with self._cache_writer_lock:
+            if self._cache_writer_thread is not None:
+                return
+
+            identity = self._get_project_identity()
+            if identity is None:
+                diagnostics.warning(
+                    "Cannot start background cache writer: no project identity available"
+                )
+                return
+
+            q: queue.SimpleQueue = queue.SimpleQueue()
+            self._cache_queue = q
+            t = threading.Thread(
+                target=self._cache_writer_thread_target,
+                args=(identity, q),
+                daemon=True,
+                name="CacheWriter",
+            )
+            t.start()
+            self._cache_writer_thread = t
+
+    def _cache_writer_thread_target(self, identity: Any, q: queue.SimpleQueue) -> None:
+        """Background thread target: own a cache connection and write file caches."""
+        from .._persistence.cache_manager import CacheManager
+
+        try:
+            cache_manager = CacheManager(identity, skip_schema_recreation=False)
+        except Exception as e:
+            diagnostics.error(f"Background cache writer failed to initialize: {e}")
+            return
+
+        try:
+            while True:
+                try:
+                    item = q.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                if item is None:
+                    break
+                self._write_one(cache_manager, item)
+        finally:
+            try:
+                cache_manager.close()
+            except Exception:
+                pass
+
+    def _write_one(self, cache_manager: Any, item: _CacheWriteRequest) -> None:
+        """Persist a single file's cache from the background thread."""
+        try:
+            cache_manager.save_file_cache(
+                item.file_path,
+                item.symbols,
+                item.file_hash,
+                item.compile_args_hash,
+                item.success,
+                item.error_message,
+                item.retry_count,
+            )
+        except Exception as e:
+            diagnostics.error(f"Background cache write failed for {item.file_path}: {e}")
+
+    def _enqueue_file_cache(
+        self,
+        file_path: str,
+        symbols: List[Any],
+        file_hash: str,
+        compile_args_hash: Optional[str],
+        success: bool,
+        error_message: Optional[str],
+        retry_count: int,
+    ) -> None:
+        """Hand the per-file cache write to the background writer thread.
+
+        Falls back to a synchronous write if the background writer could not be
+        started (e.g. in tests with a mock orchestrator).
+        """
+        self._ensure_cache_writer_started()
+        q = self._cache_queue
+        if q is None:
+            self.cache_orchestrator.save_file_cache(
+                file_path,
+                symbols,
+                file_hash,
+                compile_args_hash,
+                success=success,
+                error_message=error_message,
+                retry_count=retry_count,
+            )
+            return
+
+        q.put(
+            _CacheWriteRequest(
+                file_path=file_path,
+                symbols=symbols,
+                file_hash=file_hash,
+                compile_args_hash=compile_args_hash,
+                success=success,
+                error_message=error_message,
+                retry_count=retry_count,
+            )
+        )
+
     def merge_worker_result(self, result: Tuple, file_path: str):
         """Merge symbols and call sites from a worker process result.
 
-        Also persist the per-file cache from the main process. Workers no longer
-        write cache themselves, so all SQLite writes during indexing are
-        serialized through this path.
+        In-memory indexes are updated synchronously on the main thread. The
+        per-file cache write is offloaded to a background thread so that worker
+        results can be consumed as fast as the workers produce them.
         """
         (
             _,
@@ -75,11 +207,12 @@ class WorkerResultMerger:
 
             self.symbol_store.set_file_hash(file_path, file_hash)
 
-        # Persist per-file cache from the main process. Workers deliberately skip
-        # this step so that all SQLite writes contend on a single writer instead
-        # of N worker processes.
+        # Offload the per-file cache write to the background writer thread.
+        # Workers deliberately skip this step; serializing through one background
+        # writer avoids the SQLite contention of N worker processes while still
+        # allowing the main thread to consume results asynchronously.
         if not was_cached:
-            self.cache_orchestrator.save_file_cache(
+            self._enqueue_file_cache(
                 file_path,
                 symbols if success else [],
                 file_hash,
@@ -104,3 +237,22 @@ class WorkerResultMerger:
         success = bool(res[1])
         self.merge_worker_result(res, file_path)
         return success
+
+    def flush_cache_writes(self) -> None:
+        """Flush any pending per-file cache writes and stop the background writer."""
+        with self._cache_writer_lock:
+            t = self._cache_writer_thread
+            q = self._cache_queue
+            if t is None or q is None:
+                return
+            q.put(None)
+            self._cache_writer_thread = None
+            self._cache_queue = None
+
+        t.join(timeout=120.0)
+        if t.is_alive():
+            diagnostics.warning("Background cache writer did not finish within timeout")
+
+    def close(self) -> None:
+        """Stop the background cache writer and release resources."""
+        self.flush_cache_writes()

--- a/clang_index_mcp/cpp_analyzer.py
+++ b/clang_index_mcp/cpp_analyzer.py
@@ -114,6 +114,12 @@ class CppAnalyzer:
         This should be called when the CppAnalyzer is no longer needed
         to properly close database connections and avoid resource leaks.
         """
+        if hasattr(self, "_root") and self._root is not None:
+            if (
+                hasattr(self._root, "worker_result_merger")
+                and self._root.worker_result_merger is not None
+            ):
+                self._root.worker_result_merger.close()
         if hasattr(self, "cache_manager") and self.cache_manager is not None:
             self.cache_manager.close()
 

--- a/clang_index_mcp/cpp_analyzer.py
+++ b/clang_index_mcp/cpp_analyzer.py
@@ -151,6 +151,17 @@ class CppAnalyzer:
         """
         return self._root.indexing_pipeline.index_file(file_path, force)
 
+    def index_file_with_result(self, file_path: str, force: bool = False, write_cache: bool = True):
+        """Index a single C++ file and return a structured result.
+
+        When *write_cache* is False, the caller is responsible for persisting
+        the per-file cache. This is used by worker processes so that all SQLite
+        writes can be serialized through the main process.
+        """
+        return self._root.indexing_pipeline.index_file_with_result(
+            file_path, force=force, write_cache=write_cache
+        )
+
     def index_project(
         self,
         force: bool = False,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,7 +164,8 @@ The server runs one main process and spawns worker processes for indexing.
         │               │               │
         └───────────────┼───────────────┘
                         ▼
-        Results merged into main process indexes and SQLite
+        Results merged into main process in-memory indexes;
+        per-file cache writes are handed off to a background writer thread
 ```
 
 - Workers use `spawn` multiprocessing for fork safety.
@@ -180,6 +181,7 @@ The server runs one main process and spawns worker processes for indexing.
 sequenceDiagram
     participant MP as Main Process
     participant WP as Worker Process
+    participant CWT as Cache Writer Thread
     participant DB as SQLite
 
     MP->>WP: submit(IndexingTaskSpec)
@@ -187,7 +189,6 @@ sequenceDiagram
     WP->>WP: collect parse result
     WP->>WP: bulk_write_symbols() to local indexes
     WP->>DB: save_type_aliases_batch()
-    WP->>DB: save_file_cache()
     opt parse failure
         WP->>DB: log_parse_error()
     end
@@ -199,6 +200,8 @@ sequenceDiagram
     MP->>MP: with index_lock: update SymbolIndexStore
     MP->>DB: stream_call_sites(file_path, call_sites)
     MP->>MP: update header tracker
+    MP->>CWT: enqueue file-cache write request
+    CWT->>DB: save_file_cache(...)
 ```
 
 ### What Workers Write Directly vs Return
@@ -208,17 +211,18 @@ sequenceDiagram
 | Symbols | Extract and return via `Future` | Merge into in-memory `SymbolIndexStore` | In-memory + file cache in SQLite |
 | Call sites | Extract and return via `Future` | Atomically replace per-file entries in SQLite | SQLite |
 | Type aliases | Write batch directly to SQLite | — | SQLite |
-| File cache | Write directly to SQLite | — | SQLite |
+| File cache | Skip write; return cache metadata | Enqueue to background `CacheWriterThread` | SQLite |
 | Parse errors | Append directly to JSONL | Read on demand | JSONL file |
 | Processed headers | Return via `Future` | Update `HeaderProcessingTracker` | In-memory + `header_tracker.json` |
 
-Call sites go through the main process because they require atomic per-file replacement (`DELETE` old + `INSERT` new). Type aliases and file cache are simple batch writes, so workers write them directly to reduce IPC.
+Call sites go through the main process because they require atomic per-file replacement (`DELETE` old + `INSERT` new). Type aliases are simple batch writes, so workers write them directly to reduce IPC. File cache is no longer written by workers; the main process enqueues it to a dedicated background writer thread that owns its own SQLite connection. This avoids SQLite contention between workers while keeping the main thread free to consume worker results as fast as they arrive.
 
 ### Lock Minimization
 
 - Workers parse and extract independently. They never hold the main process `index_lock`.
 - `SymbolExtractor` collects parser results during AST traversal and applies them in a single `bulk_write_symbols()` call under one lock acquisition.
 - The main process `index_lock` is held only for the brief merge of one file's results.
+- Per-file cache writes are serialized through one background `CacheWriterThread` that owns its own SQLite connection; SQLite WAL mode handles the single-writer contention.
 - SQLite WAL mode separates readers from writers; a busy handler resolves short conflicts.
 
 ### Synchronization Primitives
@@ -231,6 +235,7 @@ Call sites go through the main process because they require atomic per-file repl
 | `_tools_event` | `threading.Event` | Tool-call priority over indexing | `_mcp/state_manager.py` |
 | `_indexed_event` | `threading.Event` | Completion signal for indexing | `_mcp/state_manager.py` |
 | SQLite WAL + busy handler | SQLite | Persistent cache | `_persistence/sqlite_cache_backend.py` |
+| `WorkerResultMerger` cache writer queue | `queue.SimpleQueue` | Pending per-file cache writes | `_indexing/worker_result_merger.py` |
 | Header tracker lock | `threading.Lock` | `HeaderProcessingTracker` state | `_persistence/header_tracker.py` |
 
 ### Indexing vs Query Synchronization

--- a/tests/test_incremental_analyzer.py
+++ b/tests/test_incremental_analyzer.py
@@ -14,7 +14,18 @@ from clang_index_mcp._incremental.incremental_analyzer import AnalysisResult, In
 def _fake_process_file_worker(spec):
     """Fake worker that succeeds unless the file path contains 'fail'."""
     success = "fail" not in spec.file_path
-    return (spec.file_path, success, False, [], [], {})
+    return (
+        spec.file_path,
+        success,
+        False,
+        [],
+        [],
+        {},
+        "file-hash",
+        "compile-args-hash",
+        None,
+        0,
+    )
 
 
 def _make_mock_ctx(test_dir):


### PR DESCRIPTION
This PR moves per-file SQLite cache writes from worker processes to a dedicated background writer thread in the main process.

### What changed
- Workers no longer call "save_file_cache" directly; they return cache metadata to the main process.
- WorkerResultMerger now enqueues per-file cache writes to a background CacheWriterThread that owns its own CacheManager/SQLite connection.
- The main thread updates in-memory indexes synchronously and keeps consuming worker results asynchronously.
- Added flush_cache_writes()/close() and wired them into ProjectIndexingOrchestrator, RefreshPipeline, and CppAnalyzer.close().
- Updated docs/ARCHITECTURE.md to reflect the new flow.

### Benchmark (clean cache, /home/andrey/myoffice/AI/co-build-debug.json, 21 files)
| variant | real | user | sys |
|---|---|---|---|
| baseline (main + is_project_file fix) | ~43.8 s | ~7m17s | ~1m09s |
| serial through-main cache writes | ~97.8 s | ~7m27s | ~1m35s |
| background cache writer | ~55.0 s | ~7m22s | ~1m12s |

The async writer recovers most of the regression (~44% faster than serial), though it is still ~26% slower than the pre-regression baseline. Further gains likely require batching multiple file caches into fewer SQLite transactions or tuning max_workers.
