### PR TITLE
Fix outdated scripts and clean up compile_commands_parser import

### DIFF
--- a/clang_index_mcp/_compilation/compile_commands_parser.py
+++ b/clang_index_mcp/_compilation/compile_commands_parser.py
@@ -11,13 +11,9 @@ import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from clang.cindex import CompilationDatabase
 
 # Handle both package and script imports
-try:
-    from clang.cindex import CompilationDatabase
-except ImportError:
-    CompilationDatabase = None  # type: ignore[assignment,misc]
-
 try:
     from .._core import diagnostics
     from .._core.argument_sanitizer import ArgumentSanitizer
@@ -173,7 +169,7 @@ def sanitize_args_for_libclang(args: List[str], argument_sanitizer: ArgumentSani
 def process_compile_command_entry(
     entry: dict,
     index: int,
-    compdb: "CompilationDatabase",
+    compdb: CompilationDatabase,
     project_root: Path,
     argument_sanitizer: ArgumentSanitizer,
 ) -> Optional[Tuple[str, dict]]:

--- a/scripts/analyze_tool_usage.py
+++ b/scripts/analyze_tool_usage.py
@@ -24,8 +24,8 @@ from typing import Any, Dict, List, Optional, Tuple
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from clang_index_mcp._search.smart_fallback import (  # noqa: E402
-    _PROTOTYPE_PATTERN,
-    _looks_like_signature,
+    PROTOTYPE_PATTERN,
+    looks_like_signature,
 )
 
 # Same regex meta detection as tool_call_logger
@@ -44,9 +44,9 @@ _MCP_PLUGIN_IDS = {"cpp-analyzer", "clang-index-mcp"}
 
 def _classify_pattern(pattern: str) -> str:
     """Classify a search pattern (same logic as server-side logger)."""
-    if _looks_like_signature(pattern):
+    if looks_like_signature(pattern):
         return "signature_like"
-    if _PROTOTYPE_PATTERN.search(pattern):
+    if PROTOTYPE_PATTERN.search(pattern):
         return "prototype_like"
     has_colons = "::" in pattern
     has_meta = bool(_REGEX_META.search(pattern))

--- a/scripts/diagnose_args.py
+++ b/scripts/diagnose_args.py
@@ -13,11 +13,11 @@ from clang_index_mcp._compilation.compile_commands_manager import (  # noqa: E40
 )
 
 
-def diagnose_file_args(project_root: str, file_path: str):
+def diagnose_file_args(project_root_arg: str, file_path_arg: str):
     """Diagnose compilation arguments for a specific file."""
 
-    project_root = Path(project_root).resolve()
-    file_path = Path(file_path).resolve()
+    project_root = Path(project_root_arg).resolve()
+    file_path = Path(file_path_arg).resolve()
 
     print(f"=== Diagnosing Arguments for {file_path.name} ===\n")
     print(f"Project root: {project_root}")

--- a/scripts/diagnose_cache.py
+++ b/scripts/diagnose_cache.py
@@ -19,7 +19,6 @@ from typing import Any, Dict
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from clang_index_mcp._persistence.schema_migrations import SchemaMigration  # noqa: E402
 from clang_index_mcp._persistence.sqlite_cache_backend import SqliteCacheBackend  # noqa: E402
 
 
@@ -134,22 +133,32 @@ class CacheDiagnostic:
         }
 
         try:
-            migration = SchemaMigration(backend.conn)
-            current_version = migration.get_current_version()
+            assert backend.conn is not None
+            cursor = backend.conn.execute("SELECT value FROM cache_metadata WHERE key = 'version'")
+            result = cursor.fetchone()
             expected_version = backend.CURRENT_SCHEMA_VERSION
 
-            if current_version != expected_version:
-                if current_version < expected_version:
-                    check["warnings"].append(
-                        f"Schema outdated: v{current_version} (expected v{expected_version})"
-                    )
-                    check["suggestions"].append("Schema will be auto-upgraded on next use")
-                else:
-                    check["passed"] = False
-                    check["issues"].append(
-                        f"Schema too new: v{current_version} (expected v{expected_version})"
-                    )
-                    check["suggestions"].append("Update your code or delete the cache")
+            if result is None:
+                check["passed"] = False
+                check["issues"].append(
+                    f"No schema version metadata found (expected v{expected_version})"
+                )
+                check["suggestions"].append("Delete the cache and re-index the project")
+            else:
+                current_version = json.loads(result[0])
+
+                if current_version != expected_version:
+                    if current_version < expected_version:
+                        check["warnings"].append(
+                            f"Schema outdated: v{current_version} (expected v{expected_version})"
+                        )
+                        check["suggestions"].append("Schema will be auto-upgraded on next use")
+                    else:
+                        check["passed"] = False
+                        check["issues"].append(
+                            f"Schema too new: v{current_version} (expected v{expected_version})"
+                        )
+                        check["suggestions"].append("Update your code or delete the cache")
 
         except Exception as e:
             check["issues"].append(f"Schema version check failed: {e}")
@@ -167,6 +176,7 @@ class CacheDiagnostic:
         }
 
         try:
+            assert backend.conn is not None
             # Get list of indexes
             cursor = backend.conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
@@ -209,6 +219,7 @@ class CacheDiagnostic:
         }
 
         try:
+            assert backend.conn is not None
             # Check FTS5 table exists
             cursor = backend.conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='symbols_fts'"
@@ -248,6 +259,7 @@ class CacheDiagnostic:
         }
 
         try:
+            assert backend.conn is not None
             cursor = backend.conn.execute("PRAGMA journal_mode")
             journal_mode = cursor.fetchone()[0].lower()
 
@@ -280,6 +292,7 @@ class CacheDiagnostic:
                 check["warnings"].append(f"Database is very large: {db_size_mb:.1f} MB")
                 check["suggestions"].append("Consider running VACUUM to reclaim space")
 
+            assert backend.conn is not None
             # Check for wasted space
             cursor = backend.conn.execute("PRAGMA freelist_count")
             freelist_count = cursor.fetchone()[0]

--- a/scripts/diagnose_compile_commands.py
+++ b/scripts/diagnose_compile_commands.py
@@ -110,7 +110,7 @@ def test_argument_extraction(project_root: Path, compile_commands: list):
                 print(f"Resolved path: {file_path.resolve()}")
 
 
-def test_single_file_parse(project_root: Path, file_to_test: str = None):
+def test_single_file_parse(project_root: Path, file_to_test: str | None = None):
     """Test parsing a single file with detailed error output"""
     print(f"\n{'=' * 70}")
     print("SINGLE FILE PARSE TEST")
@@ -119,6 +119,7 @@ def test_single_file_parse(project_root: Path, file_to_test: str = None):
     # Create analyzer
     analyzer = CppAnalyzer(str(project_root))
     ccm = analyzer.context.compile_commands_manager
+    assert ccm is not None
 
     # Get files from compile commands
     files = ccm.get_all_files()
@@ -157,8 +158,16 @@ def test_single_file_parse(project_root: Path, file_to_test: str = None):
         print("[PASS] File parsed successfully!")
         # Show symbols found by querying SQLite
         symbol_count = 0
-        if analyzer.cache_manager and analyzer.cache_manager.backend:
+        if (
+            analyzer.cache_manager
+            and analyzer.cache_manager.backend
+            and analyzer.cache_manager.backend
+        ):
             try:
+                from clang_index_mcp._persistence.sqlite_cache_backend import SqliteCacheBackend
+
+                assert type(analyzer.cache_manager.backend) is SqliteCacheBackend
+                assert analyzer.cache_manager.backend.conn is not None
                 cursor = analyzer.cache_manager.backend.conn.execute(
                     "SELECT COUNT(*) FROM symbols WHERE file = ?", (test_file,)
                 )

--- a/scripts/diagnose_parse_errors.py
+++ b/scripts/diagnose_parse_errors.py
@@ -19,15 +19,15 @@ from clang.cindex import Index, TranslationUnit, TranslationUnitLoadError  # noq
 from clang_index_mcp.cpp_analyzer import CppAnalyzer  # noqa: E402
 
 
-def diagnose_file(project_path: str, file_path: str):
+def diagnose_file(project_path_str: str, file_path_str: str):
     """Diagnose parsing issues for a specific file."""
     print("=" * 80)
     print("C++ MCP Server - Parse Error Diagnostics")
     print("=" * 80)
     print()
 
-    project_path = Path(project_path).absolute()
-    file_path = Path(file_path).absolute()
+    project_path = Path(project_path_str).absolute()
+    file_path = Path(file_path_str).absolute()
 
     if not project_path.exists():
         print(f"Error: Project path does not exist: {project_path}")
@@ -51,6 +51,7 @@ def diagnose_file(project_path: str, file_path: str):
     print(f"   Clang resource dir: {clang_resource_dir or 'NOT FOUND'}")
     print()
 
+    assert ccm is not None
     # Get compilation arguments
     print("2. Getting compilation arguments...")
     args = ccm.get_compile_args_with_fallback(file_path)

--- a/scripts/investigate_usr.py
+++ b/scripts/investigate_usr.py
@@ -385,8 +385,8 @@ int main() {
         analyzer = CppAnalyzer(project_root=str(tmp_path))
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
-        print("Indexing main.cpp...")
-        analyzer.index_file(str(main_cpp))
+        print("Indexing project (so all files, including headers, are persisted)...")
+        analyzer.index_project(include_dependencies=False)
 
         # Now check what's in SQLite
         print("\nQuerying SQLite directly...")
@@ -407,6 +407,11 @@ int main() {
         if len(rows) > 1:
             print("\n*** POTENTIAL BUG: Multiple SQLite entries with same name! ***")
             print("    Check if USRs are different or if one is empty.")
+        elif len(rows) == 0:
+            print(
+                "\nNote: index_file() only persists symbols for the requested file; "
+                "header symbols are kept in memory until index_project() saves the full index."
+            )
 
 
 def test_empty_usr_handling():

--- a/scripts/investigate_usr.py
+++ b/scripts/investigate_usr.py
@@ -38,6 +38,7 @@ public:
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
 
         # Enable debug to see definition-wins messages
         get_logger().set_level(DiagnosticLevel.DEBUG)
@@ -91,6 +92,7 @@ public:
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         # Index forward declaration first
@@ -146,6 +148,7 @@ namespace ns {
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         print(f"Indexing forward decl: {fwd_h}")
@@ -202,6 +205,7 @@ int main() {
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         # This simulates what happens in real project indexing
@@ -267,6 +271,7 @@ int main() {
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         # Index the source file (which will parse both included headers)
@@ -325,6 +330,7 @@ class FwdClass4 {
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         print(f"Indexing {fwd_h}...")
@@ -383,6 +389,7 @@ int main() {
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         print("Indexing project (so all files, including headers, are persisted)...")
@@ -439,6 +446,7 @@ class NormalClass {
 """)
 
         analyzer = CppAnalyzer(project_root=str(tmp_path))
+        assert analyzer.context.symbol_store is not None
         get_logger().set_level(DiagnosticLevel.DEBUG)
 
         print(f"Indexing {test_h}...")

--- a/scripts/investigate_usr.py
+++ b/scripts/investigate_usr.py
@@ -46,8 +46,10 @@ public:
         analyzer.index_file(str(test_h))
 
         # Check what's in class_index
-        print(f"\nclass_index['MyClass'] entries: {len(analyzer.class_index.get('MyClass', []))}")
-        for i, sym in enumerate(analyzer.class_index.get("MyClass", [])):
+        print(
+            f"\nclass_index['MyClass'] entries: {len(analyzer.context.symbol_store.class_index.get('MyClass', []))}"
+        )
+        for i, sym in enumerate(analyzer.context.symbol_store.class_index.get("MyClass", [])):
             print(f"  [{i}] file={sym.file}:{sym.line}")
             print(f"      USR={sym.usr}")
             print(f"      is_definition={sym.is_definition}")
@@ -55,9 +57,9 @@ public:
 
         # Check usr_index
         print(
-            f"\nusr_index entries with 'MyClass': {sum(1 for k in analyzer.usr_index if 'MyClass' in k)}"
+            f"\nusr_index entries with 'MyClass': {sum(1 for k in analyzer.context.symbol_store.usr_index if 'MyClass' in k)}"
         )
-        for usr, sym in analyzer.usr_index.items():
+        for usr, sym in analyzer.context.symbol_store.usr_index.items():
             if "MyClass" in usr:
                 print(f"  USR={usr}")
                 print(f"  -> {sym.file}:{sym.line}, is_definition={sym.is_definition}")
@@ -96,8 +98,10 @@ public:
         analyzer.index_file(str(fwd_h))
 
         print("\nAfter indexing forward declaration:")
-        print(f"class_index['MyClass'] entries: {len(analyzer.class_index.get('MyClass', []))}")
-        for i, sym in enumerate(analyzer.class_index.get("MyClass", [])):
+        print(
+            f"class_index['MyClass'] entries: {len(analyzer.context.symbol_store.class_index.get('MyClass', []))}"
+        )
+        for i, sym in enumerate(analyzer.context.symbol_store.class_index.get("MyClass", [])):
             print(f"  [{i}] USR={sym.usr}")
             print(f"      is_definition={sym.is_definition}, file={sym.file}:{sym.line}")
 
@@ -106,8 +110,10 @@ public:
         analyzer.index_file(str(myclass_h))
 
         print("\nAfter indexing definition:")
-        print(f"class_index['MyClass'] entries: {len(analyzer.class_index.get('MyClass', []))}")
-        for i, sym in enumerate(analyzer.class_index.get("MyClass", [])):
+        print(
+            f"class_index['MyClass'] entries: {len(analyzer.context.symbol_store.class_index.get('MyClass', []))}"
+        )
+        for i, sym in enumerate(analyzer.context.symbol_store.class_index.get("MyClass", [])):
             print(f"  [{i}] USR={sym.usr}")
             print(f"      is_definition={sym.is_definition}, file={sym.file}:{sym.line}")
 
@@ -145,7 +151,7 @@ namespace ns {
         print(f"Indexing forward decl: {fwd_h}")
         analyzer.index_file(str(fwd_h))
 
-        fwd_symbols = analyzer.class_index.get("MyClass", [])
+        fwd_symbols = analyzer.context.symbol_store.class_index.get("MyClass", [])
         print(f"\nAfter forward decl - entries: {len(fwd_symbols)}")
         for sym in fwd_symbols:
             print(f"  USR={sym.usr}")
@@ -154,7 +160,7 @@ namespace ns {
         print(f"\nIndexing definition: {myclass_h}")
         analyzer.index_file(str(myclass_h))
 
-        def_symbols = analyzer.class_index.get("MyClass", [])
+        def_symbols = analyzer.context.symbol_store.class_index.get("MyClass", [])
         print(f"\nAfter definition - entries: {len(def_symbols)}")
         for sym in def_symbols:
             print(f"  USR={sym.usr}")
@@ -202,8 +208,10 @@ int main() {
         print("Indexing main.cpp (which includes both headers)...")
         analyzer.index_file(str(main_cpp))
 
-        print(f"\nclass_index['Widget'] entries: {len(analyzer.class_index.get('Widget', []))}")
-        for i, sym in enumerate(analyzer.class_index.get("Widget", [])):
+        print(
+            f"\nclass_index['Widget'] entries: {len(analyzer.context.symbol_store.class_index.get('Widget', []))}"
+        )
+        for i, sym in enumerate(analyzer.context.symbol_store.class_index.get("Widget", [])):
             print(f"  [{i}] USR={sym.usr}")
             print(f"      file={sym.file}:{sym.line}")
             print(f"      is_definition={sym.is_definition}")
@@ -265,15 +273,17 @@ int main() {
         print("Indexing main.cpp (includes both widget.h and qstring.h)...")
         analyzer.index_file(str(main_cpp))
 
-        print(f"\nclass_index['QString'] entries: {len(analyzer.class_index.get('QString', []))}")
-        for i, sym in enumerate(analyzer.class_index.get("QString", [])):
+        print(
+            f"\nclass_index['QString'] entries: {len(analyzer.context.symbol_store.class_index.get('QString', []))}"
+        )
+        for i, sym in enumerate(analyzer.context.symbol_store.class_index.get("QString", [])):
             print(f"  [{i}] USR={sym.usr}")
             print(f"      file={sym.file}:{sym.line}")
             print(f"      is_definition={sym.is_definition}")
             print(f"      start_line={sym.start_line}, end_line={sym.end_line}")
 
         # Check if both are present (the bug!)
-        symbols = analyzer.class_index.get("QString", [])
+        symbols = analyzer.context.symbol_store.class_index.get("QString", [])
         if len(symbols) > 1:
             print("\n*** BUG DETECTED: Multiple entries for same class! ***")
             for i, sym in enumerate(symbols):
@@ -321,8 +331,8 @@ class FwdClass4 {
         analyzer.index_file(str(fwd_h))
 
         print("\nChecking USRs for all indexed classes:")
-        for name in sorted(analyzer.class_index.keys()):
-            symbols = analyzer.class_index[name]
+        for name in sorted(analyzer.context.symbol_store.class_index.keys()):
+            symbols = analyzer.context.symbol_store.class_index[name]
             print(f"\n  {name}: {len(symbols)} symbol(s)")
             for i, sym in enumerate(symbols):
                 has_usr = bool(sym.usr)
@@ -333,9 +343,9 @@ class FwdClass4 {
 
         # Check usr_index for duplicates
         print("\n\nUSR index entries:")
-        for usr in sorted(analyzer.usr_index.keys()):
+        for usr in sorted(analyzer.context.symbol_store.usr_index.keys()):
             if any(name in usr for name in ["FwdClass1", "FwdClass2", "FwdClass3", "FwdClass4"]):
-                sym = analyzer.usr_index[usr]
+                sym = analyzer.context.symbol_store.usr_index[usr]
                 print(f"  {usr}: {sym.name} is_definition={sym.is_definition}")
 
 
@@ -430,7 +440,7 @@ class NormalClass {
         analyzer.index_file(str(test_h))
 
         print("\nChecking for symbols with empty USRs:")
-        for name, symbols in analyzer.class_index.items():
+        for name, symbols in analyzer.context.symbol_store.class_index.items():
             for sym in symbols:
                 if not sym.usr:
                     print(f"  *** EMPTY USR: {name} in {sym.file}:{sym.line}")

--- a/scripts/investigate_usr.py
+++ b/scripts/investigate_usr.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from clang_index_mcp.cpp_analyzer import CppAnalyzer  # noqa: E402
 from clang_index_mcp._core.diagnostics import DiagnosticLevel, get_logger  # noqa: E402
+from clang_index_mcp._persistence.sqlite_cache_backend import SqliteCacheBackend  # noqa: E402
 
 
 def test_usr_matching_same_file():
@@ -398,6 +399,7 @@ int main() {
         # Now check what's in SQLite
         print("\nQuerying SQLite directly...")
         cache_backend = analyzer.cache_manager.backend
+        assert isinstance(cache_backend, SqliteCacheBackend)
 
         # Query for all TestClass entries
         cursor = cache_backend.conn.execute(

--- a/scripts/investigate_usr.py
+++ b/scripts/investigate_usr.py
@@ -400,6 +400,7 @@ int main() {
         print("\nQuerying SQLite directly...")
         cache_backend = analyzer.cache_manager.backend
         assert isinstance(cache_backend, SqliteCacheBackend)
+        assert cache_backend.conn is not None
 
         # Query for all TestClass entries
         cursor = cache_backend.conn.execute(

--- a/scripts/test_compile_commands_lookup.py
+++ b/scripts/test_compile_commands_lookup.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from clang_index_mcp.cpp_analyzer import CppAnalyzer  # noqa: E402
 
 
-def test_compile_commands_lookup(project_path: str, test_file: str):
+def test_compile_commands_lookup(project_path_str: str, test_file_str: str):
     """Test if a specific file gets its args from compile_commands.json"""
 
     print("=" * 80)
@@ -19,8 +19,8 @@ def test_compile_commands_lookup(project_path: str, test_file: str):
     print("=" * 80)
     print()
 
-    project_path = Path(project_path).absolute()
-    test_file = Path(test_file).absolute()
+    project_path = Path(project_path_str).absolute()
+    test_file = Path(test_file_str).absolute()
 
     print(f"Project: {project_path}")
     print(f"Test file: {test_file}")
@@ -31,6 +31,7 @@ def test_compile_commands_lookup(project_path: str, test_file: str):
     analyzer = CppAnalyzer(str(project_path))
 
     ccm = analyzer.context.compile_commands_manager
+    assert ccm is not None
     print(f"   Compile commands enabled: {ccm.enabled}")
     print(f"   Compile commands loaded: {len(ccm.compile_commands)} entries")
     print(f"   Compile commands path: {ccm.compile_commands_path}")

--- a/scripts/test_mcp_console.py
+++ b/scripts/test_mcp_console.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 _analyzer = None
 
 
-def test_clang_index_mcp(project_path: str, config_file: str = None):
+def test_clang_index_mcp(project_path: str, config_file: str | None = None):
     """Test the MCP server with a real codebase"""
 
     # Configure libclang exactly like production MCP server
@@ -64,6 +64,10 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     call_sites_count = 0
     total_symbols = 0
     if analyzer.cache_manager and analyzer.cache_manager.backend:
+        from clang_index_mcp._persistence.sqlite_cache_backend import SqliteCacheBackend
+
+        assert type(analyzer.cache_manager.backend) is SqliteCacheBackend
+        assert analyzer.cache_manager.backend.conn is not None
         try:
             # Query SQLite for total call sites count
             cursor = analyzer.cache_manager.backend.conn.execute("SELECT COUNT(*) FROM call_sites")
@@ -107,6 +111,7 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 4. Search for classes
     print("\n4. Searching for classes (pattern: '.*')...")
     classes = analyzer.search_classes(".*", project_only=True)
+    assert type(classes) is list
     print(f"[OK] Found {len(classes)} classes in project")
     if classes:
         print("   First 5 classes:")
@@ -119,10 +124,12 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 5. Search for functions
     print("\n5. Searching for functions (pattern: '.*')...")
     functions = analyzer.search_functions(".*", project_only=True)
+    assert type(functions) is list
     print(f"[OK] Found {len(functions)} functions in project")
     if functions:
         print("   First 5 functions:")
         for func in functions[:5]:
+            assert type(func) is dict
             name = func.get("qualified_name") or func.get("name")
             loc = func.get("definition") or func.get("declaration")
             loc_str = f"{loc['file']}:{loc['line']}" if loc else "unknown"
@@ -131,6 +138,7 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 6. Get detailed class info (if classes exist)
     if classes:
         cls_name = classes[0].get("qualified_name") or classes[0].get("name")
+        assert type(cls_name) is str
         print(f"\n6. Getting detailed info for class: {cls_name}")
         class_info = analyzer.get_class_info(cls_name)
         if class_info:
@@ -155,6 +163,7 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 7. Get function signature (if functions exist)
     if functions:
         func_name = functions[0].get("qualified_name") or functions[0].get("name")
+        assert type(func_name) is str
         print(f"\n7. Getting signature for function: {func_name}")
         signatures = analyzer.get_function_signature(func_name)
         if signatures:
@@ -166,6 +175,7 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 8. Get class hierarchy (if classes exist)
     if classes:
         cls_name = classes[0].get("qualified_name") or classes[0].get("name")
+        assert type(cls_name) is str
         print(f"\n8. Getting class hierarchy for: {cls_name}")
         hierarchy = analyzer.get_class_hierarchy(cls_name)
         if hierarchy and "queried_class" in hierarchy:
@@ -184,6 +194,7 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 9. Find callers (if functions exist)
     if functions:
         func_name = functions[0].get("qualified_name") or functions[0].get("name")
+        assert type(func_name) is str
         print(f"\n9. Finding callers of function: {func_name}")
         callers_result = analyzer.find_incoming_calls(func_name)
         callers_list = callers_result.get("callers", [])
@@ -199,6 +210,7 @@ def test_clang_index_mcp(project_path: str, config_file: str = None):
     # 10. Find callees (if functions exist)
     if functions and len(functions) > 1:
         func_name = functions[0].get("qualified_name") or functions[0].get("name")
+        assert type(func_name) is str
         print(f"\n10. Finding callees of function: {func_name}")
         callees_result = analyzer.find_callees(func_name)
         callees_list = callees_result.get("callees", [])


### PR DESCRIPTION
This PR updates several diagnostic/support scripts that had drifted out of sync with the analyzer's internal APIs, and removes an unnecessary defensive import.

## Changes

- **scripts/investigate_usr.py**: Update to use `analyzer.context.symbol_store`, add presence asserts for `symbol_store` and SQLite backend/connection, and make Test 7 use `index_project`.
- **scripts/diagnose_cache.py**: Fix schema version comparison logic.
- **scripts/diagnose_args.py**: Avoid overriding string arguments with Path objects by using dedicated local variables.
- **scripts/diagnose_compile_commands.py**: Fix type hints and add assertions for static analyzers.
- **scripts/analyze_tool_usage.py**, **scripts/diagnose_parse_errors.py**, **scripts/test_compile_commands_lookup.py**, **scripts/test_mcp_console.py**: Minor static-analyzer cleanups (assertions, type hints).
- **clang_index_mcp/_compilation/compile_commands_parser.py**: Replace unnecessary `try/except ImportError` for `CompilationDatabase` with a direct import; `libclang` is a hard dependency and the fallback was unused.

## Validation

- `make test-fast` — passed
- `make check` (format, lint, type-check) — passed