### PR TITLE
Avoid materializing CompileCommands list just to check emptiness

### DIFF
--- a/clang_index_mcp/_compilation/compile_commands_parser.py
+++ b/clang_index_mcp/_compilation/compile_commands_parser.py
@@ -187,7 +187,7 @@ def process_compile_command_entry(
     normalized_path = normalize_path(file_path, directory, project_root)
 
     compile_cmds = compdb.getCompileCommands(normalized_path)
-    if compile_cmds is None or len(list(compile_cmds)) == 0:
+    if compile_cmds is None or len(compile_cmds) == 0:
         compile_cmds = compdb.getCompileCommands(file_path)
 
     if compile_cmds is None:


### PR DESCRIPTION
## Summary

Replace `len(list(compile_cmds)) == 0` with `len(compile_cmds) == 0` in `compile_commands_parser.py`.

## Rationale

`cindex.CompileCommands` exposes `__len__` (backed by `clang_CompileCommands_getSize`), so there is no need to build a temporary list of `CompileCommand` objects only to check whether the container is empty. The old code worked because Python's iterator protocol falls back to `__getitem__`, but it was unnecessarily expensive.

## Backward compatibility

`__len__` has been part of the `CompileCommands` Python wrapper since it was introduced (verified in LLVM commit 89341e7 from 2012). The project already requires `libclang>=16.0.0`, so this is safe.

## Verification

- `make test-fast` passes (1443 passed, 17 skipped, 4 xpassed; 10 serial passed)
- `make format-check`, `make lint`, and `make type-check` pass
