### PR TITLE
refactor: add missing return types for a few __init__ methods to make…

### DIFF
--- a/clang_index_mcp/_core/cancellation_coordinator.py
+++ b/clang_index_mcp/_core/cancellation_coordinator.py
@@ -13,7 +13,7 @@ from .._core import diagnostics
 class CancellationCoordinator:
     """Manages cooperative cancellation of long-running indexing operations."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._interrupted: bool = False
         self._interrupt_lock = threading.Lock()
 

--- a/clang_index_mcp/_mcp/state_manager.py
+++ b/clang_index_mcp/_mcp/state_manager.py
@@ -28,7 +28,7 @@ class AnalyzerState(Enum):
 class AnalyzerStateManager:
     """Thread-safe state management for analyzer lifecycle"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._state = AnalyzerState.UNINITIALIZED
         self._lock = Lock()
         self._indexed_event = Event()  # Signals when indexing completes

--- a/clang_index_mcp/_persistence/header_tracker.py
+++ b/clang_index_mcp/_persistence/header_tracker.py
@@ -37,7 +37,7 @@ class HeaderProcessingTracker:
         _in_progress: Set of headers currently being processed
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the header processing tracker."""
         self._lock = Lock()
 

--- a/clang_index_mcp/_search/call_graph.py
+++ b/clang_index_mcp/_search/call_graph.py
@@ -72,7 +72,7 @@ class CallSite:
 class CallGraphAnalyzer:
     """Manages call graph analysis for C++ code with line-level precision."""
 
-    def __init__(self, cache_backend=None):
+    def __init__(self, cache_backend=None) -> None:
         """
         Initialize CallGraphAnalyzer.
 


### PR DESCRIPTION
Change adds missing return type typehints for a few `__init__` methods.