### PR TITLE
refactor: type SymbolContext.call_graph_service via a symbols-layer port

### DIFF
--- a/clang_index_mcp/_symbols/ports/__init__.py
+++ b/clang_index_mcp/_symbols/ports/__init__.py
@@ -2,12 +2,14 @@
 
 from .alias_persistence import AliasPersistence
 from .call_graph import CallGraphPort
+from .call_graph_service import CallGraphServiceProtocol
 from .lock_provider import LockProvider
 from .parser import ParseResult, SymbolParser
 
 __all__ = [
     "AliasPersistence",
     "CallGraphPort",
+    "CallGraphServiceProtocol",
     "LockProvider",
     "ParseResult",
     "SymbolParser",

--- a/clang_index_mcp/_symbols/ports/call_graph_service.py
+++ b/clang_index_mcp/_symbols/ports/call_graph_service.py
@@ -1,0 +1,16 @@
+"""Call graph service port for the symbols/domain layer."""
+
+from typing import Any, Protocol
+
+
+class CallGraphServiceProtocol(Protocol):
+    """Minimal interface the symbols layer needs from the call graph service.
+
+    Implemented by ``_search.call_graph_service.CallGraphService`` and wired
+    by the composition root. Defined as a port in the symbols layer so the
+    dependency direction stays ``_search`` -> ``_symbols``; attributes are
+    typed as ``Any`` to avoid referencing search-layer types from here.
+    """
+
+    call_graph_analyzer: Any
+    dependency_graph: Any

--- a/clang_index_mcp/_symbols/symbol_context.py
+++ b/clang_index_mcp/_symbols/symbol_context.py
@@ -1,8 +1,9 @@
 """Symbol extraction and call-graph domain context."""
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Optional
 
+from .ports.call_graph_service import CallGraphServiceProtocol
 from .symbol_extractor import SymbolExtractor
 from .symbol_index_store import SymbolIndexStore
 
@@ -13,4 +14,4 @@ class SymbolContext:
 
     symbol_store: Optional[SymbolIndexStore] = None
     symbol_extractor: Optional[SymbolExtractor] = None
-    call_graph_service: Optional[Any] = None
+    call_graph_service: Optional[CallGraphServiceProtocol] = None

--- a/clang_index_mcp/project_context.py
+++ b/clang_index_mcp/project_context.py
@@ -29,9 +29,9 @@ from ._persistence.cache_orchestrator import CacheOrchestrator
 from ._persistence.persistence_context import PersistenceContext
 from ._persistence.project_identity import ProjectIdentity
 from ._persistence.sqlite_cache_backend import SqliteCacheBackend
-from ._search.call_graph_service import CallGraphService
 from ._search.query_context import QueryContext
 from ._search.query_engine import QueryEngine
+from ._symbols.ports.call_graph_service import CallGraphServiceProtocol
 from ._symbols.symbol_context import SymbolContext
 from ._symbols.symbol_extractor import SymbolExtractor
 from ._symbols.symbol_index_store import SymbolIndexStore
@@ -147,7 +147,7 @@ class ProjectContext:
         return self.runtime.progress_reporter
 
     @property
-    def call_graph_service(self) -> Optional[CallGraphService]:
+    def call_graph_service(self) -> Optional[CallGraphServiceProtocol]:
         return self.symbols.call_graph_service
 
     @property


### PR DESCRIPTION
## Summary

`SymbolContext.call_graph_service` was typed `Optional[Any]` even though it always holds a `CallGraphService` (wired in `composition_root.py`). This PR types it properly without violating the project's layer rules:

- Adds `CallGraphServiceProtocol` in `clang_index_mcp/_symbols/ports/call_graph_service.py` (following the existing ports pattern, e.g. `CallGraphPort`, `SymbolParser`).
- Types `SymbolContext.call_graph_service` as `Optional[CallGraphServiceProtocol]`.
- Updates `ProjectContext.call_graph_service` property annotation to match.

## Why a Protocol instead of the concrete type

The established dependency direction is `_search` → `_symbols`. A direct import of `CallGraphService` (which lives in `_search/call_graph_service.py`) from `_symbols` would invert that direction — and since `call_graph_service.py` imports from `_symbols` at module level, it would also create a runtime circular import. Defining the port in the symbols layer keeps the dependency direction intact; `CallGraphService` satisfies it structurally with no changes to `_search`.

The protocol declares only what consumers of the context field actually use (`call_graph_analyzer` and `dependency_graph` attributes), kept as `Any` to avoid referencing search-layer types from the symbols layer — consistent with existing style (e.g. `symbol_store: Any` in `CallGraphService`).

## Performance

Typing-only change: no executable statements were modified, added, or removed. Annotations are erased at runtime and the stored object remains the concrete `CallGraphService` instance, so runtime behavior and performance are identical by construction.

## Validation

- `make check` (black, flake8, mypy) — passed
- `make test-fast` — passed
- Pre-push hook (same checks as CI) — passed