### PR TITLE
refactor: extract worker-side composition root into worker_bootstrap.py

### DIFF
--- a/.ai/CLAUDE.md
+++ b/.ai/CLAUDE.md
@@ -228,7 +228,7 @@ Refactored into packages:
 - File descriptors remain stable at ~10-15 during indexing (tested with 5700+ files)
 - **Historical Issue:** self.translation_units dict was removed (write-only, caused 516+ FD leak)
 - See `clang_index_mcp/_indexing/indexing_pipeline.py` (`SingleFileIndexingPipeline._finalize_index_success()`) for explicit TU deletion
-- See `clang_index_mcp/_indexing/worker_pool.py` (`_process_file_worker()`) for worker cleanup
+- See `clang_index_mcp/worker_bootstrap.py` (`_process_file_worker()`) for worker cleanup
 - See `clang_index_mcp/_persistence/header_tracker.py`
 
 **5. SQLite Cache with FTS5**
@@ -290,7 +290,7 @@ Refactored into packages:
 - **Project Context / DI Container:** `clang_index_mcp/project_context.py` (`ProjectContext`)
 - **Full-Project Indexing:** `clang_index_mcp/_indexing/indexing_orchestrator.py` (`ProjectIndexingOrchestrator`)
 - **Single-File Indexing Pipeline:** `clang_index_mcp/_indexing/indexing_pipeline.py` (`SingleFileIndexingPipeline`)
-- **Worker Pool:** `clang_index_mcp/_indexing/worker_pool.py` (`_process_file_worker()`)
+- **Worker Pool:** `clang_index_mcp/_indexing/worker_pool.py` (`WorkerPoolManager`, executor lifecycle); worker-side entry point in `clang_index_mcp/worker_bootstrap.py` (`_process_file_worker()`)
 - **Symbol Extraction Coordination:** `clang_index_mcp/_symbols/symbol_extractor.py` (`SymbolExtractor.index_translation_unit()`)
 - **AST Traversal:** `clang_index_mcp/_compilation/clang_symbol_parser.py` (`ClangSymbolParser._process_cursor()`)
 - **Type Alias Extraction:** `clang_index_mcp/_symbols/alias_extractor.py` (`extract_alias_info()`)

--- a/.ai/CLAUDE.md
+++ b/.ai/CLAUDE.md
@@ -204,7 +204,7 @@ Refactored into packages:
 - Bypasses Python's GIL for true parallelism on multi-core systems
 - Each worker process gets isolated memory space (no shared state)
 - 6-7x speedup on 4+ core systems
-- Worker function: `_process_file_worker()` (module-level for pickling)
+- Worker function: `process_file_worker()` (module-level for pickling)
 - Uses the `spawn` multiprocessing start method for fork safety
 
 **2. Header Deduplication (First-Win Strategy)**
@@ -228,7 +228,7 @@ Refactored into packages:
 - File descriptors remain stable at ~10-15 during indexing (tested with 5700+ files)
 - **Historical Issue:** self.translation_units dict was removed (write-only, caused 516+ FD leak)
 - See `clang_index_mcp/_indexing/indexing_pipeline.py` (`SingleFileIndexingPipeline._finalize_index_success()`) for explicit TU deletion
-- See `clang_index_mcp/worker_bootstrap.py` (`_process_file_worker()`) for worker cleanup
+- See `clang_index_mcp/worker_bootstrap.py` (`process_file_worker()`) for worker cleanup
 - See `clang_index_mcp/_persistence/header_tracker.py`
 
 **5. SQLite Cache with FTS5**
@@ -290,7 +290,7 @@ Refactored into packages:
 - **Project Context / DI Container:** `clang_index_mcp/project_context.py` (`ProjectContext`)
 - **Full-Project Indexing:** `clang_index_mcp/_indexing/indexing_orchestrator.py` (`ProjectIndexingOrchestrator`)
 - **Single-File Indexing Pipeline:** `clang_index_mcp/_indexing/indexing_pipeline.py` (`SingleFileIndexingPipeline`)
-- **Worker Pool:** `clang_index_mcp/_indexing/worker_pool.py` (`WorkerPoolManager`, executor lifecycle); worker-side entry point in `clang_index_mcp/worker_bootstrap.py` (`_process_file_worker()`)
+- **Worker Pool:** `clang_index_mcp/_indexing/worker_pool.py` (`WorkerPoolManager`, executor lifecycle); worker-side entry point in `clang_index_mcp/worker_bootstrap.py` (`process_file_worker()`)
 - **Symbol Extraction Coordination:** `clang_index_mcp/_symbols/symbol_extractor.py` (`SymbolExtractor.index_translation_unit()`)
 - **AST Traversal:** `clang_index_mcp/_compilation/clang_symbol_parser.py` (`ClangSymbolParser._process_cursor()`)
 - **Type Alias Extraction:** `clang_index_mcp/_symbols/alias_extractor.py` (`extract_alias_info()`)

--- a/clang_index_mcp/_incremental/worker_orchestrator.py
+++ b/clang_index_mcp/_incremental/worker_orchestrator.py
@@ -142,7 +142,7 @@ def submit_tasks(
     import os
 
     from .._indexing.indexing_task_spec import IndexingTaskSpec
-    from .._indexing.worker_pool import _process_file_worker
+    from ..worker_bootstrap import _process_file_worker
     from .._incremental.compile_args_resolver import get_file_compile_args
 
     project_root = str(ctx.project_root)
@@ -273,7 +273,7 @@ def _run_analysis_loop(
 ) -> int:
     """Execute the analysis loop with executor lifecycle management."""
     from .._core import diagnostics
-    from .._indexing.worker_pool import _init_worker
+    from ..worker_bootstrap import _init_worker
 
     executor: Optional[Executor] = None
     max_workers = os.cpu_count() or 4

--- a/clang_index_mcp/_incremental/worker_orchestrator.py
+++ b/clang_index_mcp/_incremental/worker_orchestrator.py
@@ -142,7 +142,7 @@ def submit_tasks(
     import os
 
     from .._indexing.indexing_task_spec import IndexingTaskSpec
-    from ..worker_bootstrap import _process_file_worker
+    from ..worker_bootstrap import process_file_worker
     from .._incremental.compile_args_resolver import get_file_compile_args
 
     project_root = str(ctx.project_root)
@@ -153,7 +153,7 @@ def submit_tasks(
 
     return {
         executor.submit(
-            _process_file_worker,
+            process_file_worker,
             IndexingTaskSpec(
                 project_root=project_root,
                 config_file=config_file_str,
@@ -273,17 +273,17 @@ def _run_analysis_loop(
 ) -> int:
     """Execute the analysis loop with executor lifecycle management."""
     from .._core import diagnostics
-    from ..worker_bootstrap import _init_worker
+    from ..worker_bootstrap import init_worker
 
     executor: Optional[Executor] = None
     max_workers = os.cpu_count() or 4
     try:
         if mp_context:
             executor = ProcessPoolExecutor(
-                max_workers=max_workers, mp_context=mp_context, initializer=_init_worker
+                max_workers=max_workers, mp_context=mp_context, initializer=init_worker
             )
         else:
-            executor = ProcessPoolExecutor(max_workers=max_workers, initializer=_init_worker)
+            executor = ProcessPoolExecutor(max_workers=max_workers, initializer=init_worker)
 
         future_to_file = submit_tasks(ctx, executor, file_list)
         analyzed, _failed = process_loop(

--- a/clang_index_mcp/_indexing/indexing_task_submitter.py
+++ b/clang_index_mcp/_indexing/indexing_task_submitter.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List
 
 from .._indexing.indexing_task_spec import IndexingTaskSpec
-from .._indexing.worker_pool import _process_file_worker
+from ..worker_bootstrap import _process_file_worker
 
 if TYPE_CHECKING:
     from concurrent.futures import Executor, Future

--- a/clang_index_mcp/_indexing/indexing_task_submitter.py
+++ b/clang_index_mcp/_indexing/indexing_task_submitter.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List
 
 from .._indexing.indexing_task_spec import IndexingTaskSpec
-from ..worker_bootstrap import _process_file_worker
+from ..worker_bootstrap import process_file_worker
 
 if TYPE_CHECKING:
     from concurrent.futures import Executor, Future
@@ -57,7 +57,7 @@ class IndexingTaskSubmitter:
 
         return {
             executor.submit(
-                _process_file_worker,
+                process_file_worker,
                 IndexingTaskSpec(
                     project_root=str(self.project_root),
                     config_file=config_file_str,
@@ -91,7 +91,7 @@ class IndexingTaskSubmitter:
 
         for f in modified_files:
             future = executor.submit(
-                _process_file_worker,
+                process_file_worker,
                 IndexingTaskSpec(
                     project_root=project_root,
                     config_file=config_file_str,
@@ -104,7 +104,7 @@ class IndexingTaskSubmitter:
             future_to_file[future] = f
         for f in new_files:
             future = executor.submit(
-                _process_file_worker,
+                process_file_worker,
                 IndexingTaskSpec(
                     project_root=project_root,
                     config_file=config_file_str,

--- a/clang_index_mcp/_indexing/worker_pool.py
+++ b/clang_index_mcp/_indexing/worker_pool.py
@@ -3,8 +3,8 @@ Worker pool and parallel execution management for C++ Analyzer.
 
 This module contains only the parent-process side: WorkerPoolManager owns the
 ProcessPoolExecutor lifecycle (setup, shutdown, termination). The worker-side
-entry points that run inside spawned child processes (_init_worker,
-_process_file_worker, and the process-local analyzer instance) live in
+entry points that run inside spawned child processes (init_worker,
+process_file_worker, and the process-local analyzer instance) live in
 ``clang_index_mcp/worker_bootstrap.py``, the designated worker-side
 composition root.
 """
@@ -21,10 +21,10 @@ from typing import Any, List, Optional
 # Handle both package and script imports
 try:
     from .._core import diagnostics
-    from ..worker_bootstrap import _init_worker
+    from ..worker_bootstrap import init_worker
 except ImportError:
     import diagnostics  # type: ignore[no-redef]
-    from worker_bootstrap import _init_worker  # type: ignore[no-redef]
+    from worker_bootstrap import init_worker  # type: ignore[no-redef]
 
 
 class WorkerPoolManager:
@@ -43,13 +43,13 @@ class WorkerPoolManager:
             self.executor = ProcessPoolExecutor(
                 max_workers=self.max_workers,
                 mp_context=self.mp_context,
-                initializer=_init_worker,
+                initializer=init_worker,
             )
         except Exception as e:
             diagnostics.warning(f"Failed to use 'spawn' context: {e}. Falling back to default.")
             self.executor = ProcessPoolExecutor(
                 max_workers=self.max_workers,
-                initializer=_init_worker,
+                initializer=init_worker,
             )
 
         return self.executor

--- a/clang_index_mcp/_indexing/worker_pool.py
+++ b/clang_index_mcp/_indexing/worker_pool.py
@@ -1,146 +1,30 @@
 """
 Worker pool and parallel execution management for C++ Analyzer.
+
+This module contains only the parent-process side: WorkerPoolManager owns the
+ProcessPoolExecutor lifecycle (setup, shutdown, termination). The worker-side
+entry points that run inside spawned child processes (_init_worker,
+_process_file_worker, and the process-local analyzer instance) live in
+``clang_index_mcp/worker_bootstrap.py``, the designated worker-side
+composition root.
 """
 
-import atexit
-import gc
-import io
 import multiprocessing
-import os
-import signal
 import sys
 import time
 from concurrent.futures import (
     Executor,
     ProcessPoolExecutor,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 # Handle both package and script imports
 try:
     from .._core import diagnostics
-    from .._indexing.indexing_task_spec import IndexingTaskSpec
+    from ..worker_bootstrap import _init_worker
 except ImportError:
     import diagnostics  # type: ignore[no-redef]
-    from indexing_task_spec import IndexingTaskSpec  # type: ignore[no-redef]
-
-# Global analyzer instance for each worker process
-# This is a process-local global, NOT shared between processes
-_worker_analyzer = None
-
-
-def _init_worker():
-    """Initializer for each worker process.
-
-    Ignores SIGINT so that Ctrl+C in the parent does not produce
-    KeyboardInterrupt tracebacks in workers.  The parent controls
-    worker lifetime via SIGTERM/SIGKILL.
-    """
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-
-def _cleanup_worker_analyzer():
-    """Ensure worker analyzer resources are released on process exit.
-
-    Suppresses stderr during close to avoid noisy libclang cleanup
-    errors (_CXString.__del__, cursor visitor assertions) that occur
-    when the interpreter is shutting down and C-level objects are
-    garbage-collected after libclang's shared library may already be
-    partially torn down.
-    """
-    global _worker_analyzer
-    if _worker_analyzer is not None:
-        saved = sys.stderr
-        sys.stderr = io.StringIO()
-        try:
-            _worker_analyzer.close()
-        except Exception:
-            pass
-        finally:
-            sys.stderr = saved
-            _worker_analyzer = None
-
-
-def _process_file_worker(spec: IndexingTaskSpec):
-    """
-    Worker function for ProcessPoolExecutor-based parallel parsing.
-
-    This is a module-level function (required for pickling) that uses
-    a shared, process-local CppAnalyzer instance to parse a single file.
-    """
-    global _worker_analyzer
-
-    # Lazy import to avoid circular dependency at module level
-    from ..cpp_analyzer import CppAnalyzer
-
-    # Create a single analyzer instance per worker process (process-local)
-    if _worker_analyzer is None:
-        diagnostics.debug(f"Worker process {os.getpid()}: Creating shared CppAnalyzer instance")
-        _worker_analyzer = CppAnalyzer(
-            spec.project_root,
-            spec.config_file,
-            skip_schema_recreation=True,
-            use_compile_commands_manager=False,
-        )
-        # Ensure cleanup is called when the worker process exits
-        atexit.register(_cleanup_worker_analyzer)
-
-    assert _worker_analyzer is not None
-    context = _worker_analyzer.context
-    assert context.compilation_env is not None
-    assert context.call_graph_service is not None
-    assert context.symbol_store is not None
-    assert context.cache_orchestrator is not None
-
-    # Set per-call parameters
-    context.compilation_env.include_dependencies = spec.include_dependencies
-    # Reset stateful components to prevent data leakage between files
-    context.call_graph_service.call_graph_analyzer.clear()
-
-    # Set precomputed compile args
-    context.compilation_env.provided_compile_args = spec.compile_args
-
-    # Parse the file, but do not write cache here; the main process will
-    # serialize all per-file cache writes to avoid SQLite contention.
-    result = _worker_analyzer.index_file_with_result(spec.file_path, spec.force, write_cache=False)
-
-    # Extract symbols from this file
-    symbols: List[Any] = []
-    call_sites: List[Any] = []
-    processed_headers: Dict[str, str] = {}
-    if result.success:
-        for fpath, file_symbols in context.symbol_store.iter_file_items():
-            symbols.extend(file_symbols)
-
-        # Extract call sites collected during this file's parsing
-        call_sites = context.call_graph_service.call_graph_analyzer.get_all_call_sites()
-
-        # Extract header tracking information
-        processed_headers = context.cache_orchestrator.get_processed_headers()
-
-    # Clean up worker indexes to prevent memory leaks (Issue #14)
-    context.symbol_store.clear_all_indexes()
-
-    # Force garbage collection to free TranslationUnit objects.
-    # Wrap in try/except because libclang's __del__ methods may raise
-    # if the C library state is inconsistent after a partial parse.
-    try:
-        gc.collect()
-    except Exception:
-        pass
-
-    return (
-        spec.file_path,
-        result.success,
-        result.was_cached,
-        symbols,
-        call_sites,
-        processed_headers,
-        result.file_hash,
-        result.compile_args_hash,
-        result.error_message,
-        result.retry_count,
-    )
+    from worker_bootstrap import _init_worker  # type: ignore[no-redef]
 
 
 class WorkerPoolManager:

--- a/clang_index_mcp/worker_bootstrap.py
+++ b/clang_index_mcp/worker_bootstrap.py
@@ -12,7 +12,7 @@ dependency direction:
 
     cpp_analyzer (facade) -> composition_root (wiring) -> _indexing (policy)
 
-The CppAnalyzer import is intentionally deferred into _process_file_worker():
+The CppAnalyzer import is intentionally deferred into process_file_worker():
 this module sits on the composition_root import chain (composition_root ->
 _indexing.indexing_task_submitter -> worker_bootstrap), so a module-level
 import of the facade would create a circular import in the parent process.
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 _worker_analyzer: Optional["CppAnalyzer"] = None
 
 
-def _init_worker():
+def init_worker():
     """Initializer for each worker process.
 
     Ignores SIGINT so that Ctrl+C in the parent does not produce
@@ -77,7 +77,7 @@ def _cleanup_worker_analyzer():
             _worker_analyzer = None
 
 
-def _process_file_worker(spec: IndexingTaskSpec):
+def process_file_worker(spec: IndexingTaskSpec):
     """
     Worker function for ProcessPoolExecutor-based parallel parsing.
 

--- a/clang_index_mcp/worker_bootstrap.py
+++ b/clang_index_mcp/worker_bootstrap.py
@@ -1,0 +1,162 @@
+"""
+Worker-side composition root for spawned indexing processes.
+
+The functions in this module run INSIDE spawned worker processes, not in the
+parent. This module is the designated composition root for workers: a live
+CppAnalyzer (libclang handles, SQLite connections) cannot be pickled across
+the process boundary, so each worker process rebuilds its own analyzer here.
+
+Keeping the concrete CppAnalyzer construction in this top-level module —
+rather than in ``_indexing/worker_pool.py`` — preserves the intended
+dependency direction:
+
+    cpp_analyzer (facade) -> composition_root (wiring) -> _indexing (policy)
+
+The CppAnalyzer import is intentionally deferred into _process_file_worker():
+this module sits on the composition_root import chain (composition_root ->
+_indexing.indexing_task_submitter -> worker_bootstrap), so a module-level
+import of the facade would create a circular import in the parent process.
+
+The executor lifecycle itself (setup/shutdown) is managed in the parent by
+``_indexing/worker_pool.py`` (WorkerPoolManager).
+"""
+
+import atexit
+import gc
+import io
+import os
+import signal
+import sys
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+# Handle both package and script imports
+try:
+    from ._core import diagnostics
+    from ._indexing.indexing_task_spec import IndexingTaskSpec
+except ImportError:
+    import diagnostics  # type: ignore[no-redef]
+    from indexing_task_spec import IndexingTaskSpec  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from .cpp_analyzer import CppAnalyzer
+
+# Global analyzer instance for each worker process
+# This is a process-local global, NOT shared between processes
+_worker_analyzer: Optional["CppAnalyzer"] = None
+
+
+def _init_worker():
+    """Initializer for each worker process.
+
+    Ignores SIGINT so that Ctrl+C in the parent does not produce
+    KeyboardInterrupt tracebacks in workers.  The parent controls
+    worker lifetime via SIGTERM/SIGKILL.
+    """
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def _cleanup_worker_analyzer():
+    """Ensure worker analyzer resources are released on process exit.
+
+    Suppresses stderr during close to avoid noisy libclang cleanup
+    errors (_CXString.__del__, cursor visitor assertions) that occur
+    when the interpreter is shutting down and C-level objects are
+    garbage-collected after libclang's shared library may already be
+    partially torn down.
+    """
+    global _worker_analyzer
+    if _worker_analyzer is not None:
+        saved = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            _worker_analyzer.close()
+        except Exception:
+            pass
+        finally:
+            sys.stderr = saved
+            _worker_analyzer = None
+
+
+def _process_file_worker(spec: IndexingTaskSpec):
+    """
+    Worker function for ProcessPoolExecutor-based parallel parsing.
+
+    This is a module-level function (required for pickling) that uses
+    a shared, process-local CppAnalyzer instance to parse a single file.
+    """
+    global _worker_analyzer
+
+    # Deferred import: this module is on the composition_root import chain
+    # (composition_root -> indexing_task_submitter -> worker_bootstrap), so a
+    # module-level import of the facade would be circular in the parent
+    # process. This line only ever executes inside a worker process.
+    from .cpp_analyzer import CppAnalyzer
+
+    # Create a single analyzer instance per worker process (process-local)
+    if _worker_analyzer is None:
+        diagnostics.debug(f"Worker process {os.getpid()}: Creating shared CppAnalyzer instance")
+        _worker_analyzer = CppAnalyzer(
+            spec.project_root,
+            spec.config_file,
+            skip_schema_recreation=True,
+            use_compile_commands_manager=False,
+        )
+        # Ensure cleanup is called when the worker process exits
+        atexit.register(_cleanup_worker_analyzer)
+
+    assert _worker_analyzer is not None
+    context = _worker_analyzer.context
+    assert context.compilation_env is not None
+    assert context.call_graph_service is not None
+    assert context.symbol_store is not None
+    assert context.cache_orchestrator is not None
+
+    # Set per-call parameters
+    context.compilation_env.include_dependencies = spec.include_dependencies
+    # Reset stateful components to prevent data leakage between files
+    context.call_graph_service.call_graph_analyzer.clear()
+
+    # Set precomputed compile args
+    context.compilation_env.provided_compile_args = spec.compile_args
+
+    # Parse the file, but do not write cache here; the main process will
+    # serialize all per-file cache writes to avoid SQLite contention.
+    result = _worker_analyzer.index_file_with_result(spec.file_path, spec.force, write_cache=False)
+
+    # Extract symbols from this file
+    symbols: List[Any] = []
+    call_sites: List[Any] = []
+    processed_headers: Dict[str, str] = {}
+    if result.success:
+        for fpath, file_symbols in context.symbol_store.iter_file_items():
+            symbols.extend(file_symbols)
+
+        # Extract call sites collected during this file's parsing
+        call_sites = context.call_graph_service.call_graph_analyzer.get_all_call_sites()
+
+        # Extract header tracking information
+        processed_headers = context.cache_orchestrator.get_processed_headers()
+
+    # Clean up worker indexes to prevent memory leaks (Issue #14)
+    context.symbol_store.clear_all_indexes()
+
+    # Force garbage collection to free TranslationUnit objects.
+    # Wrap in try/except because libclang's __del__ methods may raise
+    # if the C library state is inconsistent after a partial parse.
+    try:
+        gc.collect()
+    except Exception:
+        pass
+
+    return (
+        spec.file_path,
+        result.success,
+        result.was_cached,
+        symbols,
+        call_sites,
+        processed_headers,
+        result.file_hash,
+        result.compile_args_hash,
+        result.error_message,
+        result.retry_count,
+    )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,7 @@ Core responsibilities:
 | **Frameworks / Drivers** | `_compilation/clang_parser.py`, `_compilation/clang_symbol_parser.py` | libclang parsing |
 | | `_core/libclang_setup.py`, `_core/file_scanner.py` | libclang setup and file discovery |
 | | `_indexing/worker_pool.py` | `ProcessPoolExecutor` |
+| | `worker_bootstrap.py` | Worker-side composition root (spawned processes) |
 | | `libclang/` | libclang binaries |
 
 ### Dependency Rule
@@ -276,7 +277,7 @@ stateDiagram-v2
 | Change SQLite schema | `clang_index_mcp/schema.sql`, `_persistence/sqlite_cache_backend.py` (`CURRENT_SCHEMA_VERSION`) |
 | Change incremental refresh | `_incremental/incremental_analyzer.py`, `_incremental/change_scanner.py`, `_search/dependency_graph.py` |
 | Change header deduplication | `_persistence/header_tracker.py` |
-| Change parallel execution | `_indexing/worker_pool.py`, `_indexing/indexing_task_submitter.py`, `_indexing/worker_result_merger.py` |
+| Change parallel execution | `_indexing/worker_pool.py`, `worker_bootstrap.py`, `_indexing/indexing_task_submitter.py`, `_indexing/worker_result_merger.py` |
 | Change compilation args / compile_commands | `_compilation/compile_commands_manager.py`, `_compilation/compilation_environment.py` |
 | Wire dependencies | `composition_root.py` |
 | Thin public API | `cpp_analyzer.py` |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -49,7 +49,7 @@ This document captures the functional requirements for the Clang Index MCP Serve
 **REQ-1.2.5**: The system SHALL use ProcessPoolExecutor to bypass Python's Global Interpreter Lock (GIL):
 - Provides true parallelism on multi-core systems (6-7x speedup on 4+ cores)
 - Each worker process has isolated memory space (no shared state)
-- Worker function (`_process_file_worker()`) defined at module level for pickling compatibility
+- Worker function (`process_file_worker()`) defined at module level for pickling compatibility
 - Uses the `spawn` multiprocessing start method for fork safety
 
 ---

--- a/tests/test_incremental_analyzer.py
+++ b/tests/test_incremental_analyzer.py
@@ -116,7 +116,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
             ).ThreadPoolExecutor(max_workers=max_workers or 2),
         )
         self._worker_patch = patch(
-            "clang_index_mcp._indexing.worker_pool._process_file_worker",
+            "clang_index_mcp.worker_bootstrap._process_file_worker",
             side_effect=_fake_process_file_worker,
         )
         self._pool_patch.start()

--- a/tests/test_incremental_analyzer.py
+++ b/tests/test_incremental_analyzer.py
@@ -116,7 +116,7 @@ class TestIncrementalAnalyzer(unittest.TestCase):
             ).ThreadPoolExecutor(max_workers=max_workers or 2),
         )
         self._worker_patch = patch(
-            "clang_index_mcp.worker_bootstrap._process_file_worker",
+            "clang_index_mcp.worker_bootstrap.process_file_worker",
             side_effect=_fake_process_file_worker,
         )
         self._pool_patch.start()


### PR DESCRIPTION
## Summary

`_indexing/worker_pool.py` mixed two concerns:

- **Parent-side**: `WorkerPoolManager` — executor lifecycle (setup, shutdown, SIGTERM/SIGKILL)
- **Worker-side**: `_process_file_worker`, `_init_worker`, `_cleanup_worker_analyzer`, and the process-local `_worker_analyzer` global — code that only ever runs inside spawned child processes

The worker function also instantiated the top-level `CppAnalyzer` facade from inside the `_indexing` layer, inverting the intended dependency direction (`cpp_analyzer → composition_root → _indexing`) and forming a latent import cycle, suppressed only by a lazy import.

## Change

- New top-level `clang_index_mcp/worker_bootstrap.py` — the designated **worker-side composition root**. A live `CppAnalyzer` (libclang handles, SQLite connections) cannot be pickled across the `spawn` boundary, so each worker process must rebuild its own object graph; Clean Architecture's Main-component concept permits naming concretions exactly there.
- `worker_pool.py` now contains only `WorkerPoolManager` (parent-side executor lifecycle); it imports `_init_worker` from the bootstrap module.
- The `_worker_analyzer` global is now annotated `Optional["CppAnalyzer"]` via `TYPE_CHECKING`, matching the codebase idiom.
- The `CppAnalyzer` import stays deferred inside `_process_file_worker()` — documented in the module docstring: `worker_bootstrap` sits on the `composition_root → indexing_task_submitter` import chain, so a module-level facade import would be circular in the parent process.
- Import sites updated: `indexing_task_submitter.py`, `_incremental/worker_orchestrator.py`, and the patch target in `tests/test_incremental_analyzer.py`.
- Docs updated: `docs/ARCHITECTURE.md`.

**No behavior change** — code moved verbatim apart from import paths and the type annotation.

## Validation

- `make check` (black, flake8, mypy) — clean
- `make test-fast` (xdist + serial stages) — passed locally and re-run by the pre-push hook
- Import smoke test confirmed no circular imports across `worker_bootstrap`, `worker_pool`, `indexing_task_submitter`, `worker_orchestrator`, `cpp_analyzer`, `composition_root`