### PR TITLE
chore: add type hints to CppAnalyzer facade and delegated methods

### DIFF
--- a/clang_index_mcp/_search/query_engine.py
+++ b/clang_index_mcp/_search/query_engine.py
@@ -7,7 +7,7 @@ and file-based symbol lookup.
 """
 
 import re
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from .._search.file_symbol_finder import find_in_file, get_files_containing_symbol
 from .._search.hierarchy_analyzer import get_class_hierarchy
@@ -41,7 +41,7 @@ class QueryEngine:
         project_root: "Path",
         search_engine: Optional[SearchEngine] = None,
         smart_fallback: Optional[SmartFallback] = None,
-    ):
+    ) -> None:
         """
         Initialize query engine.
 
@@ -76,7 +76,7 @@ class QueryEngine:
         """
         return self
 
-    def pop_last_fallback(self):
+    def pop_last_fallback(self) -> Optional[FallbackResult]:
         """Return and clear the last fallback result.
 
         Called by the MCP server layer to retrieve smart suggestions
@@ -94,7 +94,7 @@ class QueryEngine:
         namespace: Optional[str] = None,
         max_results: Optional[int] = None,
         include_base_classes: bool = True,
-    ):
+    ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], int]]:
         """Search for classes matching pattern"""
         from .._core import diagnostics
 
@@ -133,7 +133,7 @@ class QueryEngine:
         max_results: Optional[int] = None,
         signature_pattern: Optional[str] = None,
         include_attributes: bool = False,
-    ):
+    ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], int]]:
         """Search for functions matching pattern, optionally within a specific class"""
         from .._core import diagnostics
 
@@ -210,7 +210,7 @@ class QueryEngine:
         namespace: Optional[str] = None,
         max_results: Optional[int] = None,
         signature_pattern: Optional[str] = None,
-    ):
+    ) -> Union[Dict[str, List[Dict[str, Any]]], Tuple[Dict[str, List[Dict[str, Any]]], int]]:
         """Search for all symbols (classes and functions) matching pattern."""
         from .._core import diagnostics
 

--- a/clang_index_mcp/cpp_analyzer.py
+++ b/clang_index_mcp/cpp_analyzer.py
@@ -17,9 +17,12 @@ analyzer.context.symbol_store) or through the public wrapper methods
 """
 
 import sys
-from typing import Any, Dict, List, Optional
+from types import TracebackType
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 from .composition_root import CompositionRoot
+from ._indexing.indexing_pipeline import IndexingResult
+from ._search.smart_fallback import FallbackResult
 from ._symbols.indexing_callbacks import IndexingCallbacks
 
 # Handle both package and script imports
@@ -54,7 +57,7 @@ class CppAnalyzer:
         config_file: Optional[str] = None,
         skip_schema_recreation: bool = False,
         use_compile_commands_manager: bool = True,
-    ):
+    ) -> None:
         """
         Initialize C++ Analyzer.
 
@@ -96,7 +99,7 @@ class CppAnalyzer:
         self.cache_dir = self._root.cache_manager.cache_dir
         self.cache_orchestrator = self._root.cache_orchestrator
 
-    def interrupt(self):
+    def interrupt(self) -> None:
         """
         Interrupt any ongoing indexing operations.
         Sets the interrupted flag which is checked by indexing loops.
@@ -107,7 +110,7 @@ class CppAnalyzer:
         """Check if indexing has been interrupted."""
         return self._root.cancellation.is_interrupted()
 
-    def close(self):
+    def close(self) -> None:
         """
         Close the analyzer and release all resources.
 
@@ -123,16 +126,21 @@ class CppAnalyzer:
         if hasattr(self, "cache_manager") and self.cache_manager is not None:
             self.cache_manager.close()
 
-    def __enter__(self):
+    def __enter__(self) -> "CppAnalyzer":
         """Context manager entry."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Literal[False]:
         """Context manager exit."""
         self.close()
         return False
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Destructor to ensure resources are released on garbage collection."""
         # During Python shutdown, modules may be None. Suppress all errors.
         try:
@@ -157,7 +165,9 @@ class CppAnalyzer:
         """
         return self._root.indexing_pipeline.index_file(file_path, force)
 
-    def index_file_with_result(self, file_path: str, force: bool = False, write_cache: bool = True):
+    def index_file_with_result(
+        self, file_path: str, force: bool = False, write_cache: bool = True
+    ) -> IndexingResult:
         """Index a single C++ file and return a structured result.
 
         When *write_cache* is False, the caller is responsible for persisting
@@ -192,7 +202,7 @@ class CppAnalyzer:
             callbacks=callbacks,
         )
 
-    def pop_last_fallback(self):
+    def pop_last_fallback(self) -> Optional[FallbackResult]:
         """Return and clear the last fallback result (delegates to query_engine)."""
         return self._root.query_engine.pop_last_fallback()
 
@@ -204,7 +214,7 @@ class CppAnalyzer:
         namespace: Optional[str] = None,
         max_results: Optional[int] = None,
         include_base_classes: bool = True,
-    ):
+    ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], int]]:
         """Search for classes matching pattern (delegates to query_engine)."""
         return self._root.query_engine.search_classes(
             pattern, project_only, file_name, namespace, max_results, include_base_classes
@@ -220,7 +230,7 @@ class CppAnalyzer:
         max_results: Optional[int] = None,
         signature_pattern: Optional[str] = None,
         include_attributes: bool = False,
-    ):
+    ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], int]]:
         """Search for functions matching pattern (delegates to query_engine)."""
         return self._root.query_engine.search_functions(
             pattern,
@@ -277,7 +287,7 @@ class CppAnalyzer:
         namespace: Optional[str] = None,
         max_results: Optional[int] = None,
         signature_pattern: Optional[str] = None,
-    ):
+    ) -> Union[Dict[str, List[Dict[str, Any]]], Tuple[Dict[str, List[Dict[str, Any]]], int]]:
         """Search for all symbols (classes and functions) matching pattern (delegates to query_engine)."""
         return self._root.query_engine.search_symbols(
             pattern, project_only, symbol_types, namespace, max_results, signature_pattern

--- a/clang_index_mcp/cpp_analyzer_config.py
+++ b/clang_index_mcp/cpp_analyzer_config.py
@@ -83,7 +83,7 @@ class CppAnalyzerConfig:
         "diagnostics": {"level": "info", "enabled": True},  # debug, info, warning, error, fatal
     }
 
-    def __init__(self, project_root: Path, config_path: Optional[Path] = None):
+    def __init__(self, project_root: Path, config_path: Optional[Path] = None) -> None:
         self.project_root = project_root
         self.config_path = config_path  # Pre-specified config path
         self.config = self._load_config()


### PR DESCRIPTION
## Summary

Adds argument and return type annotations to methods that lacked them.

**clang_index_mcp/cpp_analyzer.py**
- `__init__`, `interrupt`, `close`, `__del__` → `-> None`
- `__enter__` → `-> "CppAnalyzer"`
- `__exit__` → typed exception args (`Optional[Type[BaseException]]`, `Optional[BaseException]`, `Optional[TracebackType]`), return `Literal[False]` (mypy's `exit-return` requirement for an `__exit__` that always returns False)
- `index_file_with_result` → `-> IndexingResult`
- `pop_last_fallback` → `-> Optional[FallbackResult]`
- `search_classes` / `search_functions` → `-> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], int]]`
- `search_symbols` → `-> Union[Dict[str, List[Dict[str, Any]]], Tuple[Dict[str, List[Dict[str, Any]]], int]]`

**clang_index_mcp/_search/query_engine.py** (delegated methods)
- Matching return types on `pop_last_fallback`, `search_classes`, `search_functions`, `search_symbols`, and `__init__`

**clang_index_mcp/cpp_analyzer_config.py**
- `__init__` → `-> None`

## Architecture note

The two new imports (`IndexingResult` from `_indexing/indexing_pipeline.py`, `FallbackResult` from `_search/smart_fallback.py`) follow the Clean Architecture dependency rule: `CppAnalyzer` is the outermost facade/wiring layer, so depending on use-case-layer types points inward, consistent with the existing `IndexingCallbacks` import. No import cycles introduced (verified by importing the module and running the full test suite).

## Validation

- `make format-check` ✓
- `make lint` ✓
- `make type-check` ✓ (no issues in 135 source files)
- `make test-fast` ✓ (1443 passed, 17 skipped, 4 xpassed + 10 serial passed) — run twice (locally and via pre-push hook)