### PR TITLE
refactor: make QueryEngine explicitly implement the SearchDependencies port

### DIFF
--- a/clang_index_mcp/_search/ports/search_deps.py
+++ b/clang_index_mcp/_search/ports/search_deps.py
@@ -48,7 +48,7 @@ class SearchConcurrency(Protocol):
 class SearchCacheManager(Protocol):
     """Minimal interface for cache access used by search type alias resolution."""
 
-    def get_canonical_for_alias(self, type_name: str) -> Any:
+    def get_canonical_for_alias(self, alias_name: str) -> Any:
         pass
 
     def get_type_alias_info(self, type_name: str) -> Any:

--- a/clang_index_mcp/_search/query_engine.py
+++ b/clang_index_mcp/_search/query_engine.py
@@ -28,8 +28,13 @@ if TYPE_CHECKING:
     from .._symbols.symbol_index_store import SymbolIndexStore
 
 
-class QueryEngine:
-    """Manages search queries and analysis operations."""
+class QueryEngine(SearchDependencies):
+    """Manages search queries and analysis operations.
+
+    Explicitly implements the SearchDependencies protocol (the search
+    layer's port), so static checkers verify conformance instead of
+    relying on implicit structural (duck) typing.
+    """
 
     def __init__(
         self,
@@ -55,18 +60,50 @@ class QueryEngine:
             search_engine: Optional pre-built SearchEngine instance.
             smart_fallback: Optional pre-built SmartFallback instance.
         """
-        self.symbol_store = symbol_store
-        self.cache_manager = cache_manager
-        self.concurrency = concurrency
-        self.compilation_env = compilation_env
-        self.call_graph_service = call_graph_service
-        self.project_root = project_root
+        # Stored in private attributes; exposed via the properties below,
+        # which implement the SearchDependencies port with concrete types.
+        self._symbol_store = symbol_store
+        self._cache_manager = cache_manager
+        self._concurrency = concurrency
+        self._compilation_env = compilation_env
+        self._call_graph_service = call_graph_service
+        self._project_root = project_root
         self.search_engine = search_engine or SearchEngine(
             symbol_store=symbol_store,
             cache_manager=cache_manager,
         )
         self.smart_fallback = smart_fallback or SmartFallback()
         self._last_fallback: Optional[FallbackResult] = None
+
+    @property
+    def symbol_store(self) -> "SymbolIndexStore":
+        """In-memory symbol indexes (narrows the port to the concrete type)."""
+        return self._symbol_store
+
+    @property
+    def cache_manager(self) -> "CacheManager":
+        """SQLite-backed cache and persistence."""
+        return self._cache_manager
+
+    @property
+    def concurrency(self) -> "ConcurrencyContext":
+        """Concurrency context with index_lock."""
+        return self._concurrency
+
+    @property
+    def compilation_env(self) -> "CompilationEnvironment":
+        """Compilation environment for compile args and file scanning."""
+        return self._compilation_env
+
+    @property
+    def call_graph_service(self) -> "CallGraphService":
+        """Call graph and dependency tracking."""
+        return self._call_graph_service
+
+    @property
+    def project_root(self) -> "Path":
+        """Project root directory."""
+        return self._project_root
 
     def _as_search_deps(self) -> SearchDependencies:
         """Return self as a SearchDependencies-compatible object.


### PR DESCRIPTION
## Summary

`QueryEngine` previously satisfied the `SearchDependencies` protocol (the search layer's port in `_search/ports/search_deps.py`) only **structurally** — duck typing. This was unobvious to readers and made PyCharm report `Expected type 'SearchDependencies', got 'Self@QueryEngine' instead` warnings at every call site that passes `self` (`query_engine.py:77, 247, 251, 257`).

## Changes

- `QueryEngine` now **explicitly inherits `SearchDependencies`** (PEP 544 explicit protocol implementation), so static checkers verify conformance instead of assuming it. This follows the same pattern as the earlier symbols-layer port refactor (#283) and does not violate Clean Architecture: the class depends on an abstraction from its own layer's `ports/` package (dependency inversion).
- The six port members (`symbol_store`, `cache_manager`, `concurrency`, `compilation_env`, `call_graph_service`, `project_root`) are now read-only `@property` getters backed by private attributes, returning the **concrete** types. This keeps full attribute access on `self` (e.g. `symbol_store.total_class_symbols()`) while satisfying the port's read-only property contract for both mypy and PyCharm.
- Aligned `SearchCacheManager.get_canonical_for_alias` parameter name (`type_name` → `alias_name`) with every implementation (`CacheManager`, `SqliteCacheBackend`, `_indexing/ports/cache_backend.py`). The port was the only outlier; all call sites are positional, so there is no runtime impact. This was a genuine structural incompatibility that stricter checkers reject.

## Verification

- `make check` — black, flake8, mypy (135 files): all pass
- `make test-fast` — full suite passes (also re-run by the pre-push hook)
- PyCharm reports **zero** type warnings in `query_engine.py` after the change (previously 4)

No behavior change.